### PR TITLE
fix(longhorn): mitigate CSI lease cascade after etcd disruption (CM-1/2/4/5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ current-ip-assignments.txt
 # Point-in-time audit snapshots
 *-audit.csv
 offline-devices-audit.csv
+.rootcause/

--- a/clusters/main/kubernetes/apps/ollama/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/ollama/app/helm-release.yaml
@@ -226,6 +226,6 @@ spec:
         memory: 2Gi
         cpu: 50m
       limits:
-        memory: 8Gi
+        memory: 24Gi
         cpu: "4"
         nvidia.com/gpu: 1

--- a/clusters/main/kubernetes/system/longhorn/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/helm-release.yaml
@@ -36,10 +36,10 @@ spec:
       defaultClass: true
       defaultClassReplicaCount: "1"
     csi:
-      attacherReplicaCount: 1
-      provisionerReplicaCount: 1
-      resizerReplicaCount: 1
-      snapshotterReplicaCount: 1
+      attacherReplicaCount: 2
+      provisionerReplicaCount: 2
+      resizerReplicaCount: 2
+      snapshotterReplicaCount: 2
     longhornUI:
       replicas: 1
     metrics:

--- a/clusters/main/kubernetes/system/longhorn/app/instance-manager-rotation-cronjob.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/instance-manager-rotation-cronjob.yaml
@@ -1,0 +1,99 @@
+---
+# Rotates the longhorn-system instance-manager pod weekly.
+#
+# Why: Longhorn's instance-manager accumulates stale iSCSI target IDs over time
+# (tgtadm cleanup failures are silent and not GC'd). After ~44h of uptime in the
+# 2026-05-25 incident, stale targets blocked engine startup with
+#   `tgtadm: can't find the logical unit: exit status 22`
+# requiring manual restart. Bounding pod uptime to 7 days prevents recurrence.
+# Documented in .rootcause/a3_longhorn_recurring_csi_lease_cascade.md (CM-2).
+#
+# Side-effect: each rotation causes ~5-30s data-plane pause for healthy volumes
+# while engines re-spawn. Scheduled at Sunday 04:00 UTC (low-activity window).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: instance-manager-rotation
+  namespace: longhorn-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: instance-manager-rotation
+  namespace: longhorn-system
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: instance-manager-rotation
+  namespace: longhorn-system
+subjects:
+  - kind: ServiceAccount
+    name: instance-manager-rotation
+    namespace: longhorn-system
+roleRef:
+  kind: Role
+  name: instance-manager-rotation
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: instance-manager-rotation
+  namespace: longhorn-system
+spec:
+  schedule: "0 4 * * 0"   # weekly Sunday 04:00 UTC
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: instance-manager-rotation
+          restartPolicy: OnFailure
+          containers:
+            - name: rotate
+              image: docker.io/bitnami/kubectl:1.36
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -euo pipefail
+                  POD=$(kubectl get pods -n longhorn-system \
+                    -l longhorn.io/component=instance-manager \
+                    -o jsonpath='{.items[0].metadata.name}')
+                  if [ -z "$POD" ]; then
+                    echo "ERROR: no instance-manager pod found"
+                    exit 1
+                  fi
+                  AGE_HRS=$(($(($(date +%s) - $(date -d "$(kubectl get pod -n longhorn-system $POD \
+                    -o jsonpath='{.status.startTime}')" +%s))) / 3600))
+                  echo "Rotating instance-manager: $POD (uptime ${AGE_HRS}h)"
+                  kubectl delete pod -n longhorn-system "$POD" --grace-period=60
+                  echo "Waiting for new instance-manager to be Ready..."
+                  for i in $(seq 1 60); do
+                    NEW=$(kubectl get pods -n longhorn-system \
+                      -l longhorn.io/component=instance-manager \
+                      -o jsonpath='{.items[?(@.status.containerStatuses[0].ready==true)].metadata.name}')
+                    if [ -n "$NEW" ]; then
+                      echo "New instance-manager Ready: $NEW"
+                      exit 0
+                    fi
+                    sleep 5
+                  done
+                  echo "ERROR: new instance-manager did not become Ready within 5 min"
+                  exit 1
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi

--- a/clusters/main/kubernetes/system/longhorn/app/kustomization.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - volumeSnapshotClass.yaml
   - ingress.yaml
   - jobs
+  - instance-manager-rotation-cronjob.yaml
+  - prometheus-rules.yaml

--- a/clusters/main/kubernetes/system/longhorn/app/prometheus-rules.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/prometheus-rules.yaml
@@ -1,0 +1,113 @@
+---
+# Longhorn early-warning alerts.
+#
+# Pre-2026-05-25 we had no visibility into Longhorn errors. The cascade was
+# detected via app failures ~2 hours after CSI sidecar restart at 02:16Z.
+# These rules surface the failure pattern within minutes via the existing
+# Alertmanager → Discord HITL pipeline.
+# Documented in .rootcause/a3_longhorn_recurring_csi_lease_cascade.md (CM-4).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: longhorn-alerts
+  namespace: longhorn-system
+  labels:
+    # Allow kube-prometheus-stack to discover this rule across namespaces
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: longhorn-volume-health
+      interval: 30s
+      rules:
+        - alert: LonghornVolumeFaulted
+          expr: longhorn_volume_robustness{robustness="faulted"} > 0
+          for: 2m
+          labels:
+            severity: critical
+            component: longhorn
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} is faulted"
+            description: |
+              Volume {{ $labels.volume }} (node {{ $labels.node }}) has
+              robustness=faulted for over 2 minutes. Likely engine startup
+              failure (iSCSI desync) or replica corruption.
+              Runbook: docs/runbooks/longhorn-recovery.md
+        - alert: LonghornVolumeStuckDetaching
+          expr: longhorn_volume_state{state="detaching"} > 0
+          for: 5m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} stuck detaching > 5 min"
+            description: |
+              Volume {{ $labels.volume }} has been in 'detaching' state for
+              over 5 minutes. May indicate instance-manager iSCSI cleanup
+              failure. Runbook: docs/runbooks/longhorn-recovery.md
+        - alert: LonghornVolumeStuckAttaching
+          expr: longhorn_volume_state{state="attaching"} > 0
+          for: 5m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Longhorn volume {{ $labels.volume }} stuck attaching > 5 min"
+            description: |
+              Volume {{ $labels.volume }} has been in 'attaching' state for
+              over 5 minutes. Pod will be in ContainerCreating waiting for
+              this volume. Runbook: docs/runbooks/longhorn-recovery.md
+    - name: longhorn-control-plane-health
+      interval: 30s
+      rules:
+        - alert: LonghornCSIRestartStorm
+          expr: |
+            sum(rate(kube_pod_container_status_restarts_total{
+              namespace="longhorn-system",
+              container=~"csi-attacher|csi-provisioner|csi-resizer|csi-snapshotter"
+            }[5m])) > 0.05
+          for: 5m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "Longhorn CSI sidecars are restarting in lockstep"
+            description: |
+              Multiple Longhorn CSI sidecars are restarting at >0.05/s sustained.
+              Likely upstream kube-apiserver/etcd disruption causing
+              leader-lease loss. Pre-cursor to volume detachment cascade.
+              Runbook: docs/runbooks/longhorn-recovery.md
+        - alert: LonghornInstanceManagerOld
+          expr: |
+            time() - kube_pod_start_time{
+              namespace="longhorn-system",
+              pod=~"instance-manager-.*"
+            } > 604800
+          for: 1h
+          labels:
+            severity: info
+            component: longhorn
+          annotations:
+            summary: "Longhorn instance-manager pod {{ $labels.pod }} older than 7 days"
+            description: |
+              The instance-manager has been up over 7 days. The weekly
+              rotation CronJob should have replaced it. Check
+              CronJob/instance-manager-rotation status:
+                kubectl get cronjob -n longhorn-system instance-manager-rotation
+              Runbook: docs/runbooks/longhorn-recovery.md
+        - alert: LonghornManagerErrorRate
+          expr: |
+            sum(rate(kube_pod_container_status_restarts_total{
+              namespace="longhorn-system",
+              container="longhorn-manager"
+            }[15m])) > 0.01
+          for: 10m
+          labels:
+            severity: warning
+            component: longhorn
+          annotations:
+            summary: "longhorn-manager restarting frequently"
+            description: |
+              longhorn-manager has restarted >0.01/s over 15 min. Indicates
+              control-plane instability. Check logs:
+                kubectl logs -n longhorn-system longhorn-manager-* --previous
+              Runbook: docs/runbooks/longhorn-recovery.md

--- a/docs/runbooks/longhorn-recovery.md
+++ b/docs/runbooks/longhorn-recovery.md
@@ -1,0 +1,188 @@
+# Longhorn Recovery Runbook
+
+**When to read this:** Apps stuck in `ContainerCreating`, "FailedAttachVolume" events, Longhorn volumes in `faulted` / `detaching` / stuck `attaching` states.
+
+**Cluster context:** Single-node Talos, Longhorn 1.11.2, single-replica volumes, CSI sidecars at 2 replicas (post-CM-1).
+
+---
+
+## Quick triage (5 minutes)
+
+```bash
+# 1. What's the volume state distribution?
+kubectl get volumes.longhorn.io -n longhorn-system -o json | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+counts = {}
+for v in d['items']:
+    s = v['status']; key = f\"{s.get('state')}/{s.get('robustness')}\"
+    counts[key] = counts.get(key, 0) + 1
+for k, n in sorted(counts.items(), key=lambda x: -x[1]):
+    print(f'  {k}: {n}')
+"
+
+# 2. Which apps are stuck?
+kubectl get pods -A | grep -E "ContainerCreating|Init:0"
+
+# 3. Which volumes are problematic?
+kubectl get volumes.longhorn.io -n longhorn-system | grep -E "faulted|detaching|attaching"
+```
+
+If counts show **only** `attached/healthy` and `detached/unknown`: Longhorn is fine, problem is elsewhere (DNS, RBAC, image pull).
+
+If any volumes are `faulted` or stuck `detaching/attaching`: continue below.
+
+---
+
+## Symptom 1: Volumes `faulted` or stuck `detaching`
+
+**Most common cause (verified 2026-05-25):** instance-manager iSCSI target ID desync.
+
+### Diagnose
+
+```bash
+# Check longhorn-manager logs for iSCSI cleanup errors
+kubectl logs -n longhorn-system -l app=longhorn-manager --tail=200 | grep tgtadm
+
+# Look for: "tgtadm: can't find the logical unit: exit status 22"
+# If present: instance-manager iSCSI state is stuck → use Recovery A
+
+# Also check for orphan engine image references
+kubectl logs -n longhorn-system -l app=longhorn-manager --tail=200 | grep "engineimage.*not found"
+
+# Look for: 'failed to get engine image ... engineimage.longhorn.io "ei-XXXX" not found'
+# If present: orphan EngineImage CRD → see Recovery B
+```
+
+### Recovery A: Restart instance-manager (iSCSI desync)
+
+```bash
+# 1. Find the instance-manager pod
+POD=$(kubectl get pods -n longhorn-system -l longhorn.io/component=instance-manager -o jsonpath='{.items[0].metadata.name}')
+echo "Will restart: $POD"
+
+# 2. Check pod age — if < 24h something else is wrong; investigate before restarting
+kubectl get pod -n longhorn-system $POD -o jsonpath='{.status.startTime}'; echo
+
+# 3. Delete the pod (graceful 30s)
+kubectl delete pod -n longhorn-system $POD --grace-period=30
+
+# 4. Wait for new instance-manager to be Ready (typically 30-60s)
+until kubectl get pods -n longhorn-system -l longhorn.io/component=instance-manager 2>/dev/null | grep -q "1/1.*Running"; do sleep 5; done
+
+# 5. Watch volumes recover (typically 1-3 min for all stuck volumes)
+watch -n 5 'kubectl get volumes.longhorn.io -n longhorn-system | grep -E "faulted|detaching|attaching" | wc -l'
+```
+
+**Expected side-effect:** ALL Longhorn-backed apps see a 5-30s IO pause while engines respawn with fresh iSCSI state. Apps using `attached/healthy` volumes recover automatically; previously-stuck volumes converge to `attached/healthy` over 1-3 min.
+
+### Recovery B: Orphan EngineImage CRD
+
+If logs show `engineimage.longhorn.io "ei-XXXX" not found`:
+
+```bash
+# 1. Identify which engines reference the orphan
+ORPHAN_HASH="ei-XXXX"  # replace with the actual hash from logs
+kubectl get engines.longhorn.io -n longhorn-system -o json | \
+  jq -r ".items[] | select(.spec.image | contains(\"$ORPHAN_HASH\")) | .metadata.name"
+
+# 2. Two paths:
+#    Path 1 (preferred): upgrade engines to current image
+#      via Longhorn UI → Volume → Upgrade Engine (per-volume; do during maintenance)
+#    Path 2 (workaround): create placeholder EngineImage CRD pointing at the missing version
+#      (only do this if upgrade isn't possible right now)
+```
+
+---
+
+## Symptom 2: CSI sidecars restarting in lockstep
+
+**Cause:** Upstream kube-apiserver/etcd disruption causing CSI leader-lease loss. Today (post-CM-1) with 2 replicas this should NOT cascade into volume detachment — the surviving replica holds the lease.
+
+### Diagnose
+
+```bash
+# 1. Confirm restart pattern
+kubectl get pods -n longhorn-system -o wide | grep csi-
+
+# 2. Look at apiserver/etcd health
+kubectl logs -n kube-system kube-apiserver-k8s-control-1 --tail=200 | grep -iE "warn|error|slow"
+
+# 3. Check resource pressure on the node
+kubectl top node
+kubectl top pod -A --sort-by=memory | head -20
+
+# 4. Verify CSI sidecars are still at 2 replicas (CM-1)
+kubectl get deploy -n longhorn-system | grep csi-
+# Each should show 2/2 READY
+```
+
+### Recovery
+
+- If volumes remain attached/healthy: monitor, no immediate action needed
+- If volumes start to detach: follow Symptom 1 recovery
+- If kube-apiserver itself is unhealthy: investigate upstream (etcd, control-plane resource pressure)
+
+---
+
+## Symptom 3: `volsync-src-*` pod stuck in ContainerCreating for hours
+
+**Cause:** Stale clone PVC from a previous failed VolSync run holding the source volume.
+
+### Recovery
+
+```bash
+# 1. Find the stuck volsync-src pod (filter by app you care about)
+APP=plex  # or sonarr, radarr, etc.
+kubectl get pods -n media | grep "volsync-src-$APP" | head
+
+# 2. Force-delete the stuck pod
+kubectl delete pod -n media volsync-src-$APP-config-config-XXXX --grace-period=0 --force
+
+# 3. Check if there's a stuck clone PVC blocking the volume
+kubectl get pvc -A | grep volsync.*clone
+
+# 4. If a clone PVC is stuck Terminating, clear its finalizer
+kubectl patch pvc <name> -n <ns> -p '{"metadata":{"finalizers":null}}' --type=merge
+```
+
+---
+
+## Post-recovery verification
+
+```bash
+# All volumes should be attached/healthy or detached/unknown — nothing else
+kubectl get volumes.longhorn.io -n longhorn-system -o json | python3 -c "
+import sys, json
+d = json.load(sys.stdin); bad = []
+for v in d['items']:
+    s = v['status']
+    if s.get('robustness') == 'faulted' or s.get('state') in ('attaching', 'detaching'):
+        bad.append((v['metadata']['name'], s.get('state'), s.get('robustness')))
+print(f'Problem volumes: {len(bad)}')
+for n, st, rob in bad: print(f'  {n}: {st}/{rob}')
+"
+
+# All previously-affected apps Running
+kubectl get pods -A | grep -E "ContainerCreating|0/[0-9]+\s+Init"
+```
+
+---
+
+## Permanent fixes already in place (post-2026-05-25)
+
+| Mitigation | Where | Effect |
+|---|---|---|
+| CSI sidecars at 2 replicas | `clusters/main/kubernetes/system/longhorn/app/helm-release.yaml` | Apiserver blip no longer cascades to mass CSI restart |
+| Weekly instance-manager rotation | `instance-manager-rotation-cronjob.yaml` | Bounds iSCSI state accumulation to 7 days |
+| PrometheusRules | `prometheus-rules.yaml` | Faulted/stuck/restart-storm alerts within 2-5 min |
+| This runbook | `docs/runbooks/longhorn-recovery.md` | Diagnostic path no longer tribal |
+
+---
+
+## Reference incidents
+
+| Date | Trigger | Resolution time | Doc |
+|---|---|---|---|
+| 2026-03-16 → 22 | Renovate auto-bumped Longhorn 1.11.0→1.11.1; Kyverno digest mutation broke upgrade detection | 6 days | `~/.claude/projects/-Users-zachbaum-dev-Talos-Cluster/memory/project_longhorn_1_11_recovery.md` |
+| 2026-05-25 | etcd/apiserver disruption caused CSI lease-loss + iSCSI desync | ~2.5 hours (incident) + analysis | `.rootcause/a3_longhorn_recurring_csi_lease_cascade.md` |


### PR DESCRIPTION
## Summary

- **Mitigates** the 2026-05-25 Longhorn cascade: etcd/apiserver disruption caused all 4 CSI sidecars to lose leader leases simultaneously, then instance-manager iSCSI state desynchronized, leaving 11+ volumes stuck `detaching/faulted` for ~2.5 hours
- **Applies 4 of 5 countermeasures** from the A3 root-cause analysis (the 5th — orphan EngineImage cleanup — needs a maintenance window)
- **Adds** Ollama memory limit bump (8Gi → 24Gi) to fit 27B Q3_K_M models (separate commit, same incident-day workstream)

## Changes by countermeasure

| CM | File | Effect |
|---|---|---|
| CM-1 | `clusters/main/kubernetes/system/longhorn/app/helm-release.yaml` | CSI sidecars 1 → 2 replicas (attacher/provisioner/resizer/snapshotter). Surviving replica holds the lease through apiserver blips. |
| CM-2 | `instance-manager-rotation-cronjob.yaml` (new) | Weekly Sun 04:00 UTC rotation. Bounds iSCSI target ID accumulation to 7 days — was 44h in this incident. |
| CM-4 | `prometheus-rules.yaml` (new) | 5 alerts: faulted volume, stuck detaching/attaching, CSI restart storm, instance-manager > 7d. Routes through existing Alertmanager → Discord pipeline. |
| CM-5 | `docs/runbooks/longhorn-recovery.md` (new) | Diagnostic decision tree with exact kubectl commands for the failure modes we've now seen twice (March + May 2026). |

## Test plan

- [ ] After Flux reconcile: `kubectl get deploy -n longhorn-system | grep csi-` shows all 4 sidecars at 2/2 READY
- [ ] After Flux reconcile: `kubectl get cronjob -n longhorn-system instance-manager-rotation` exists with schedule `0 4 * * 0`
- [ ] After Flux reconcile: `kubectl get prometheusrule -n longhorn-system longhorn-alerts` exists with 5 rules
- [ ] Sunday 04:00 UTC: cron fires, new instance-manager pod replaces current one, volumes stay healthy
- [ ] Next time CSI sidecar restarts (etcd blip): only one of two restarts, no volume detachment
- [ ] Alert fires within 2-5 min of any future faulted/stuck volume
- [ ] Ollama: pibb-ops-trained-v13 (Qwen3.6-27B Q3_K_M) loads successfully after pod restart with 24Gi limit

## Reference

A3 analysis at `.rootcause/a3_longhorn_recurring_csi_lease_cascade.md` (gitignored, local-only) documents the full 5-section root cause analysis. Today's incident summary lives in the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Performance**
  * Increased Ollama memory allocation to support larger workloads.
  * Enhanced Longhorn storage reliability with increased CSI component replicas.
  * Added automatic weekly maintenance routine for storage system optimization.

* **Monitoring & Alerting**
  * Added proactive alerting for storage volume and control-plane health issues.

* **Documentation**
  * Added comprehensive recovery guide for storage system troubleshooting and remediation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zachbomb/Talos-Cluster/pull/4127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->