### PR TITLE
feat(overseerr): migrate to Seerr v3.0.1

### DIFF
--- a/clusters/main/kubernetes/apps/media/overseerr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/overseerr/app/helm-release.yaml
@@ -18,9 +18,13 @@ spec:
         namespace: flux-system
   values:
     image:
-      repository: ghcr.io/sct/overseerr
+      # Migrated from Overseerr to Seerr per https://docs.seerr.dev/migration-guide/
+      # Schema migrates automatically on first boot from existing Overseerr DB on the
+      # same PVC; mountPath bumped to /app/config to match Seerr's Dockerfile (WORKDIR /app).
+      # renovate: datasource=docker depName=ghcr.io/seerr-team/seerr
+      repository: ghcr.io/seerr-team/seerr
       pullPolicy: IfNotPresent
-      tag: 1.35.0
+      tag: v3.0.1
     credentials:
       s3:
         type: s3
@@ -76,7 +80,9 @@ spec:
         size: 2Gi
         main:
           enabled: true
-          mountPath: /config
+          # Seerr's Dockerfile sets WORKDIR /app and writes to ./config/DOCKER —
+          # so the in-container config dir is /app/config, not /config.
+          mountPath: /app/config
         volsync:
           - name: config
             type: restic
@@ -149,6 +155,7 @@ spec:
         readOnlyRootFilesystem: false
         runAsGroup: 1000
         runAsUser: 1000
+        runAsNonRoot: true
       pod:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch


### PR DESCRIPTION
## Summary
- Migrates Overseerr to Seerr per https://docs.seerr.dev/migration-guide/
- Image: `ghcr.io/sct/overseerr:1.35.0` → `ghcr.io/seerr-team/seerr:v3.0.1`
- Config mountPath: `/config` → `/app/config` (Seerr's Dockerfile WORKDIR is `/app`)
- Adds `runAsNonRoot: true` per migration guide

## Why same Helm release name + PVC
Seerr auto-migrates the Overseerr DB on first boot. Keeping the same release name preserves the existing PVC (`pvc-827796a4-9c61-...`) so the DB is right there at `/app/config/db/db.sqlite3` when the new container starts. No data move, no fresh install, no restore-from-VolSync needed.

## Rollback
`git revert <merge-commit>` restores Overseerr 1.35.0 against the same PVC. Last successful VolSync backup was 54 min before this commit as a safety net.

## Test plan
- [ ] Flux reconciles and rolls the deployment
- [ ] Pod logs show migration / startup without errors
- [ ] UI loads at https://overseerr.\${BASE_DOMAIN}
- [ ] Existing requests, users, Sonarr/Radarr/Plex integrations intact
- [ ] Homepage widget still working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Media application upgraded to Seerr v3.0.1, replacing the previous version with improved compatibility and features.
  * Configuration paths updated to align with new application structure.

* **Security**
  * Enhanced container security by enforcing non-root user execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->