### PR TITLE
chore(secrets): refresh 3 drifted API keys (Tautulli/Plex/Seerr)

### DIFF
--- a/clusters/main/clusterenv.yaml
+++ b/clusters/main/clusterenv.yaml
@@ -40,7 +40,7 @@ SVCNET: ENC[AES256_GCM,data:9RqfTdOYTYRr0iGNpQ==,iv:g6H1Y/6lqYDWpbaoc6CB7Wdw/84t
 BASE_DOMAIN: ENC[AES256_GCM,data:pqYR6S4yVXW+RTE5z4++9O1Y,iv:wVD6K+NXhUxGGQ3hv0tUBa6iYboEd6EU8Ijg5mJNqUs=,tag:PrH6iUNEIaa79FFTU1t9bw==,type:str]
 BASE_DOMAIN2: ENC[AES256_GCM,data:+RX/0ecVkEm+MqQ0pP1z,iv:J4ocNCMZn7ysI7euFiu0E4yVoNPwCZa/KsmOrYy2nsY=,tag:SkmGhfVPsHMn1/IVHSZyyg==,type:str]
 #ENC[AES256_GCM,data:Fq6b8vVLR/9Qgz+9IrSgS6jRTFI=,iv:XrLm2XOjTfqnr51qJH6uW2pqD/Yq8M8r+acD64n4jpU=,tag:DPQd31jXcTX+QqiSR7F20Q==,type:comment]
-#ENC[AES256_GCM,data:5dv2QAAJYZ2cMJ0mnTBNg2lQxg==,iv:pMvbhRm9SaebomBbnBaiNJs1oE39ANvrDWWmaUWb68Q=,tag:lJMTUpzYzE6XPbUWgfqiQg==,type:comment]
+#ENC[AES256_GCM,data:h82wy+ALiRBsnsOQNCstFjDFtg==,iv:Lwdy4CIZmjWHo+aBtvzSXnd3lxn1mkCgcse7igNs2XA=,tag:EPy8/3iqMTJLsPuuQfFsJA==,type:comment]
 NOTIFIARR_IP: ENC[AES256_GCM,data:zzWw+4RX/wdGCwKqbCU=,iv:rgzFa3hTRYUxBoszPqIEJGqBNLQGFjculnYDULqSYSU=,tag:Tbr7sP7dvSWnmgjBbRASeQ==,type:str]
 NOTIFIARR_API: ENC[AES256_GCM,data:gqprO7FHANiymTcfHYtg6k7g5VV62SUUwmRv3BUvTGeeVYui,iv:t2PkfhN1dsLrnkHkgCcH4ivmukKjmKeYKL5IErLPXSk=,tag:Wmqdz8PCUQmHaharH12oUg==,type:str]
 NOTIFIARR_CHANNEL: ENC[AES256_GCM,data:kZ+OuXtjOB56NrQj3R2XqeLdmw==,iv:OprRGKArBZnZQTLbwcDROzlzzLKZDbhFein6d8wbs94=,tag:Pj8jvbu6Qb2CLTyD4JGnVQ==,type:str]
@@ -50,7 +50,7 @@ CROWDSEC_IP: ENC[AES256_GCM,data:9Si4Sl9OL28x8vNL/1o=,iv:myhIebWY+vpyfzH5thYV/nY
 OLLAMA_IP: ENC[AES256_GCM,data:Hw5qb2VTSLloIw5g48E=,iv:sIlPvuFgj273qzP7JN0VuGVbQvHQLw7/pWsQCNxaSXY=,tag:D3frWER8yw5HuhSJGaGZ0g==,type:str]
 #ENC[AES256_GCM,data:RIW+a7ANjoQ/fzeXralZaqaXKbCM8gHo,iv:+7H5EXAZ2GWUK4/pjACNjXmz6A5PX8ERLH3fT0MJ4M8=,tag:mwfYtEZO7HeL3h/KQ+HGmw==,type:comment]
 PLEX_IP: ENC[AES256_GCM,data:WlkZvBtJpRK2RPXgaR4=,iv:u3Qyjr6QG4PU36AynXEW9cSVri/I3W6oTPi9aXrncqQ=,tag:PY1Q35hQDGvsNOa8r1juwg==,type:str]
-PLEX_API: ENC[AES256_GCM,data:0x+lkiG1o0nhpuOCM0zJqVv0ZcI=,iv:YrX/uY6YGKrENt/FudiWK6M9msOlaZtoOQxxw8GnfxE=,tag:/olNzShjVPEYuCfT5QgSxg==,type:str]
+PLEX_API: ENC[AES256_GCM,data:N0RugrfQOUk1gHZcyI/M98gn1Ks=,iv:qnpLtrNTTOh230CR3V7eg3Rq+SbRh2N3Wv1F94ITzUI=,tag:klKTJIfUjc3Y+O69ixU6dQ==,type:str]
 EMBY_IP: ENC[AES256_GCM,data:Ms/J3DC03q/FqYKn6Z4=,iv:rxHv3Ny+WWIzB3FaeOQzktet7+1aXJv8Vg83oEHZcBw=,tag:hCB+zRjCCwHVTmQvEqyrGA==,type:str]
 EMBY_API: ENC[AES256_GCM,data:OceqPwcjyobFwXpjyWX3tfd3NQpf76gVg2so+SdF7AE=,iv:CFbAsuAMP3J8vMtZKRRNmDvrHHZ6QhKL/2KPEIXHdoI=,tag:tS35ZSbfV06k9NbzSwLPTQ==,type:str]
 TUNARR_IP: ENC[AES256_GCM,data:7XMYo5UAFQ2NwqTo+Kc=,iv:lRZOVsZo14/KDyXVWYRReSupJaveb65TbzTKKvNL1Lo=,tag:n+k1phxYRdnYM2oi41Fapg==,type:str]
@@ -65,7 +65,7 @@ NORD_VPN_USER: ENC[AES256_GCM,data:1P2jr0VvNFcUSF9fBRdPdDhsi2op81J1,iv:D4o5XSHVH
 NORD_VPN_PASS: ENC[AES256_GCM,data:hF7HUZnOW0iMVG/XNHwFa8dRUWeO+opo,iv:RnivorvaxZMu+xaA+x9rjVPjCTSAdWzouyFzXDhpt0s=,tag:AE/DcoGXHZb3bJvJ8wYwyA==,type:str]
 #ENC[AES256_GCM,data:m4v7mnQaXyTQQ1nf9u22cS8H,iv:Awl3hGlJdS0WuuXQjS7MODcmjZkk9l34+HIl41ED+yg=,tag:qDGcQhJPg4TVxNJERPoMgQ==,type:comment]
 OVERSEERR_IP: ENC[AES256_GCM,data:BrGU3fQ5Eujj0aPOq3E=,iv:wDoK++4OzGJARtwqsRAGj1Pxwpil+MSJxTA7fh+zrxM=,tag:u4W6MQYLE5Cz3uX7iQZkgA==,type:str]
-OVERSEERR_API: ENC[AES256_GCM,data:c6r9KzE6aq5my+pMRCC3AKfMxsJgoDf37w+JX6MR0l1D3zAMHwAjmeduYiCi+HBaeepjXNpu6Bt22Dli+x1UF4bgFEc=,iv:VcIm55WoWY6IJe4dH6xOigmtSuv8w2a+d0OsTPeYXXw=,tag:bWf9biPa5qhyUw1t4WIBoQ==,type:str]
+OVERSEERR_API: ENC[AES256_GCM,data:lFPY3MhHgAiKoxgMawhWN6Ivwfxv3CNZx+yzxxA7h6E1ZNKu9Ckvccb4dKQ5cTv9B/zy5Q9Vj73Bc8SCLqMPzY0XAtM=,iv:fCyvb3RkU1mex9ADvYvt1m5UpQKKWtbtvXCpi4/Qo8Y=,tag:41/DMfYPnK5hThmdo35kHw==,type:str]
 RADARR_IP: ENC[AES256_GCM,data:s6gcjj98c6yB3O92pfo=,iv:cCipijbq/taAo8W1jrMA+ubT1WLM0Za7uCRPvMfRYyA=,tag:u/YOkIdGqK6S/Qp/eEjuQg==,type:str]
 RADARR_API: ENC[AES256_GCM,data:JOk16rMolMFj4mcjRFYpzeqiEWCw+AnXqMEObZRdJdc=,iv:xy6wzOc8F0xPnERaGOoq0P/OXNWyqaklIia0DxAAOBo=,tag:EIWhBMTRWUsBbQFusYbSCA==,type:str]
 SONARR_IP: ENC[AES256_GCM,data:O/Alc1SiIeDk+xD2DaA=,iv:QL0qvff+KKHenkwCwZaLJakjomN3Fms1nNzo+4RuB38=,tag:zIm/4pQxkBi0GIYDr5twvw==,type:str]
@@ -81,11 +81,11 @@ MYLAR_API: ENC[AES256_GCM,data:5KmuYq6vIUBnRddPGKfjKVa2obPrlPTvFoEjeHv0Sqg=,iv:A
 KAPOWARR_IP: ENC[AES256_GCM,data:1eI+/aB9sPM0wg+ifrc=,iv:7gD68jeNrQW2hAka6E+4GroO5QqnVFz2wCvrFxrWeOM=,tag:mOViVroxadXEzrHX5NaXYQ==,type:str]
 #ENC[AES256_GCM,data:E395SvABy6XKfuQ1pQgMcRlKBlcLh7ztUylDkuqt,iv:KirAwklOBOWOkRqYn2Y0t2hEL2SN/D4zM8x5rrD1fLQ=,tag:KJNR0NwuDw5ldwto+06EGQ==,type:comment]
 TAUTULLI_IP: ENC[AES256_GCM,data:Upi58iHvmQuODWriIms=,iv:sfWBQfhnH/0ySroak05bMZzfplCVFCin7uwwwEgxAg4=,tag:gKtQhTTwXgXOZNY9ei1qWA==,type:str]
-TAUTULLI_API: ENC[AES256_GCM,data:TkeDxFTOaXUHF6ZE5oqTob/KBvBaKTys20qwtg5rbGU=,iv:cjqFZOOZEDaWtrXACvC3VQgoe3HPn5Qwwe/Nm0cnwV8=,tag:Jiv5aS+Mt7LXLzMjD9JcRw==,type:str]
+TAUTULLI_API: ENC[AES256_GCM,data:EB3N4lpxe5x6oZ/HFsyL+U3WyBqMiIhDYA8mGekNOP0=,iv:qNbLw0AyB94kA77N8cBeFVEsIzJMb+3NYxzlprEgt28=,tag:Dc68pUllhEcwJBOl8tyXHA==,type:str]
 BAZARR_IP: ENC[AES256_GCM,data:rEnrW49RT4ccG4PwlBk=,iv:iCuwQihjnMIzlsxB0LfIKZhF1E9GnHt004JxhVuK6aY=,tag:3HVNqNWcyMZ234aKQMpU9Q==,type:str]
 BAZARR_API: ENC[AES256_GCM,data:esX8rL/sTBd1FmW2B7nXCCwUGrnSjFCJzsw30EtOESs=,iv:ECQR6oSZp9ZI0cS+Qmeifdn+VVYCdSF+a/ymMCCQZRQ=,tag:DXd/uXbIfElK3h/6XFfMXA==,type:str]
 TINYMEDIAMANAGER_IP: ENC[AES256_GCM,data:OjuLbAqyuqxNtVWh1TM=,iv:HuqYwOvBu2Hp6HZ9Dp0FCLaZtGC9TtuyyrswkDT+Vaw=,tag:dnoYd+6tSznpER63VfvtOQ==,type:str]
-#ENC[AES256_GCM,data:x7fUn/K5akfEHTEd59pliQ==,iv:YosdymDBml8H/vYbxKsAWWayrYf+ktRFs6/J/hmi4LM=,tag:Y+fjqeThn+Rjmdj2lXsmhg==,type:comment]
+#ENC[AES256_GCM,data:ZZhKZysxytrv/ARX8rps6w==,iv:QttAo+h63l77GfWbaTyJqQmdIMgufxiBq9hZCG9uJ+Q=,tag:XxLyYfHd61ykOTRTAdMtUg==,type:comment]
 TANDOOR_IP: ENC[AES256_GCM,data:m2jNI82J374BzidP9eM=,iv:Y/Lrk5T/5xIWuVNne6DuEojBWrG8XgGTIKveM4DYIMI=,tag:i54kD7P2IlQB4vqsQPQX/A==,type:str]
 CALIBRE_IP: ENC[AES256_GCM,data:AerF25Yx3PPltf/80is=,iv:fACF94i6d/wzXaVpwHp/0MZY1rZl/aV5dS0em8HeAaU=,tag:9jiYXnWiQpWiXz0QUE4fjw==,type:str]
 CALIBRE_WEB_IP: ENC[AES256_GCM,data:p8RU8O04WYC8hnNGNCI=,iv:sFcInTARm1FTb05HiJtMJ7Ayb8rjmOpgH32oW7cdP0I=,tag:Tb4DFfv/NBYUhQCQf52thg==,type:str]
@@ -96,7 +96,7 @@ TDARR_IP: ENC[AES256_GCM,data:1BF77yBNu9IaESpXnlU=,iv:i628MFQqs0RLiqJ1ralA3+VFk3
 RECYCLARR_IP: ENC[AES256_GCM,data:eYLK6YeNms7Vc+jL1eg=,iv:fMcF7wbHOmA45xZ2Sysf3kVJJPS5gpUk8as2IS0mowc=,tag:JnN6KNyxNLo3NsHqImFH/Q==,type:str]
 FLARESOLVERR_IP: ENC[AES256_GCM,data:KHHCR5GYqLtEuatcpT4=,iv:wnD9ZPRcDudqKj0GFD/gHqXlXgw9K0Ls4ahHvs66I6w=,tag:4NOl6ALVa66+UDlekr4kTQ==,type:str]
 DISCORD_TOKEN: ENC[AES256_GCM,data:rpEuvdWZ7wkDf3NVNhaXuvTteugpJ5MJi9CPjHPWlKBqagTFrb847ODZF7d4IPtqg19a15nQAbO1QHQcoWbdfFIC9earFAlAMaVq4xHd/L+Q0wzvg6e7,iv:lQ6jdcjW7CBE0chG409PkbouO0MxiNYS7bT/0b1I3dA=,tag:RkHJTy5f4HaCqMCHRQKGsA==,type:str]
-#ENC[AES256_GCM,data:Hz80Bm+RWfk2S+Cw89y76w==,iv:9WYcwzXzxT/QpoTwag/AnY85RLGgxSMYc6YRf0oxbOc=,tag:4ybP2YC+wcKtp8Q0iyWOWA==,type:comment]
+#ENC[AES256_GCM,data:E4+qxWM2rEUy7EPeBK+Zzg==,iv:rbw15E37xMhYrqWiHU83OsX0YQTpeLlinnqjUQ6PDUs=,tag:phXQtnAmXSW9I4SSWR8Vig==,type:comment]
 READARR_IP: ENC[AES256_GCM,data:NtT5Ni2CtnlOLOEjKkc=,iv:Qyv+GB6L16Wejjgx7CzsvvK8Lnz8sDe4ue1t/AwxG9U=,tag:8jRKSEHnWBFbss2FxU4CcA==,type:str]
 READARR_API: ENC[AES256_GCM,data:KdxyoHwFRqipKaErHZloh98lHmOCLu153evQ3KYZrYE=,iv:nMPiMP2EtodQP5yZinCxLailhqn3/9Y04B2tcdpMc34=,tag:t3rPnGGYIvnrhhMSE0H5UA==,type:str]
 #ENC[AES256_GCM,data:h82wy+ALiRBsnsOQNCstFjDFtg==,iv:Lwdy4CIZmjWHo+aBtvzSXnd3lxn1mkCgcse7igNs2XA=,tag:EPy8/3iqMTJLsPuuQfFsJA==,type:comment]
@@ -180,7 +180,7 @@ sops:
             b0eB9jDk1jpD5fcwSNEFm2HRNUQg41H1cQX7r4ffx3nfcKNh0FnqEg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
-    lastmodified: "2026-05-27T18:14:25Z"
-    mac: ENC[AES256_GCM,data:VSybV3se2Shm7Xd1PGGBDuYNddX9ruH1yThQ3xv9v7HY2749k7p8xYW1YglUD2ooLPNl+buOmdOxj7iT10Rn4Y/37qS+1ILpcbRatGK3P21XBuVpCiUhrRZ5eODNRvKsHLdrOY8cZZhMf4Ezn8kENa15V7WnaC7AdR8mTPnZ7XU=,iv:fspSIifkOnYLnlIm5Bl7Fm0gycbTZPf6DS3HHO35CK0=,tag:WMmdFV+koAz8qwRBKNNZTA==,type:str]
+    lastmodified: "2026-06-09T16:51:43Z"
+    mac: ENC[AES256_GCM,data:XpLwxNofYsmqyhJNuoZE/TzmIEjO/NCw1zUzaHPIC6T8l+rfGpS8iRXYmyIGj2kcQ7cNuJPotkLCd4/7DQgD+zrbH0bKxHzLFXYnzu/8UXjyv4JkT+CI4ORQK6+D0RuE0dDKxdjPtH3s3qLe3GYjPW1cRwizYiM40V++glwfrB4=,iv:jfWWr7M2eXinyYcERH7VvJ9y07X+V478vL9+DWmmSO8=,tag:xm02ibtZZz9A9QwA5GasWg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/clusters/main/kubernetes/flux-system/flux/clustersettings.secret.yaml
+++ b/clusters/main/kubernetes/flux-system/flux/clustersettings.secret.yaml
@@ -46,7 +46,7 @@ data:
     BASE_DOMAIN: ENC[AES256_GCM,data:3gBjMxW8M01PW3opBBMKNtJM,iv:O+bJyg+kuHIXQkMfE9mQND9j8LdAfM369Djgtvi5MXc=,tag:fp3qE20wdP5xxpefT3wqwQ==,type:str]
     BASE_DOMAIN2: ENC[AES256_GCM,data:s0UZhCkr4RdzR/L64pC7,iv:i2kV5h2usmz/SxpVf1oxHp0Ao1berS3st5OX283kJis=,tag:LWysA0Ys5VM6dOuIQeN44w==,type:str]
     #ENC[AES256_GCM,data:9yH5A3X672iq44slAcd6gUiHkXE=,iv:qmEirmQA3XKqBWTHbmalzjSujO4xWOw1/6NU3yQwtmA=,tag:tZu1WHwQllp13dmdmTcZBg==,type:comment]
-    #ENC[AES256_GCM,data:20jTDy5xcZpTemc/Vn+S3lpOww==,iv:oyN7Sr/++/qCCpy+93twTT/N/8Q+15gJfejWIVb3Jmc=,tag:Uhokyl9g7iFJTpwZyS+HPA==,type:comment]
+    #ENC[AES256_GCM,data:LT18U97mWtliuM1hErpP++90xg==,iv:/MFu11ApACylO5wcScO8rgcQq1eHvxcclIq0LmGSpzk=,tag:lfkGxEBjaY3tZALxmnskeg==,type:comment]
     NOTIFIARR_IP: ENC[AES256_GCM,data:5uEL4PSsXI1iSqeiaB4=,iv:SpJoOzLwb88MnWJIqaj6su4NISz0v0oRo9aSRia59jE=,tag:hJCPYX9rzWgT8fbM4H0yFA==,type:str]
     NOTIFIARR_API: ENC[AES256_GCM,data:gqRNAnWGtPxj61kBc6ufppF3RywAB5OQM+8B5dOYJhkd8Zha,iv:VZAJaC6HzP0jH8gmFVQN1EOYj0dlOemoT4YfTaGbXJI=,tag:5/bZOOjXVQrY5IOWxNaI4A==,type:str]
     NOTIFIARR_CHANNEL: ENC[AES256_GCM,data:HS4+06M52kXWKsvWxEbvvOUL0w==,iv:p1OnuBJyEFL056U7U50MmjVIcZlVFtvvpqVVyuXjklc=,tag:qMv/xPhPkFk/H9Q9LgjCDg==,type:str]
@@ -56,7 +56,7 @@ data:
     OLLAMA_IP: ENC[AES256_GCM,data:EG+p3lMcLWxoFlxn3QI=,iv:pJqvQw8oknCC+6YydN25c/60AMpCx/l+Zv7AjWPLqns=,tag:f/TdGW2d3o1zSYIEvdFj4w==,type:str]
     #ENC[AES256_GCM,data:VgoMmmQSkrP/EI+3KTyu+SrR2rE/B6vc,iv:8gb5NaWHquV9VbYBxRya0NR3JqOZrjdV8sMCiZFOHNE=,tag:wxZjKVIbZSw+SKLUjlSXMQ==,type:comment]
     PLEX_IP: ENC[AES256_GCM,data:QAg5QeHjVSBOPg3xj0A=,iv:W8Gz77VYbTydn5tsUADlN99bGdV4r7cYsa3kf6sRFd4=,tag:gu65gGq9qN+Hwj1Qvy5MoA==,type:str]
-    PLEX_API: ENC[AES256_GCM,data:Kd9srCPYWMrIO4pYKwFDRfGQH/4=,iv:BaRG6vc8RXfyYphsrnOVX4mT/xjl9UNRoGIjD/LaXnM=,tag:esvL0+bwbGqj5Gcfi9DfgA==,type:str]
+    PLEX_API: ENC[AES256_GCM,data:JkPZIUAeyr920UFSFhnSukSMYr8=,iv:2ZSMbyPbNuB0nq0n0dH+2BlPl1Z29RrIrYrPuXivCwo=,tag:voHTNmbOYEq3YPTW3QTD/g==,type:str]
     EMBY_IP: ENC[AES256_GCM,data:XdVeT/XYTKKdYZitokY=,iv:EOWNlvxpvMCQN7lSU9j9E83FW+dmemDItS/DTZDsnPU=,tag:IL/h5ugMbWf473hLFqYKhA==,type:str]
     EMBY_API: ENC[AES256_GCM,data:0hByiooJtx/M23U6Ordc2DPM59pahqoYOn/+HP5wxCA=,iv:FZy3FcQ9434Kf6jTEsFuxNwXrDlvTb+uVJG5RyNruBc=,tag:l27jM/mT5u8bR4dT7XCi9g==,type:str]
     TUNARR_IP: ENC[AES256_GCM,data:e9i3HDRDueswazTHMao=,iv:HF04webu/eYU6y1efkmVX68JJMcujfQGt/uXiSWrm3Y=,tag:kNXJr4A2RnKV+QOzANEQgQ==,type:str]
@@ -71,7 +71,7 @@ data:
     NORD_VPN_PASS: ENC[AES256_GCM,data:jPDQ3CworiP12/p07oudgZAu/BBmrIEV,iv:fzjW28k+qDQ8y3GHkhMuVpNBJwdt2atOEJ8yO59qICg=,tag:KOnaUrKHDVS6oa/uPw7Niw==,type:str]
     #ENC[AES256_GCM,data:Q1hjRnR9mbNAlYkGVOhOS4X+,iv:8e+FNkAEC4obWdK65ZKSJ2cdngvQCGsvY4BS56UtNto=,tag:OUr1zE6sD5Y828MPi+wovQ==,type:comment]
     OVERSEERR_IP: ENC[AES256_GCM,data:8tSJGHxJ3i5F8uNTVmI=,iv:U+1GA121L/Lzph6t0zQIa0VERhM3VPsDNrpf2iXOOCI=,tag:nSNwcq1y4M+knjKhXxTbWw==,type:str]
-    OVERSEERR_API: ENC[AES256_GCM,data:Tguu+1SGlynWow6RFFntC91klEjR9iHv2C/iB0kZ3vp7QeS1fEVMVZr6D+JP6cZU4wW86BAkpCWlQ1NAHeUmUYGXScU=,iv:j7Og3Uy2RO6toy9kgYB9frClgP/ZQokerFvbuPKCgEo=,tag:YwzrXpF1i4kZSRRffFkJ0w==,type:str]
+    OVERSEERR_API: ENC[AES256_GCM,data:BxgX99FVdEcG3Yc6KZr2MBcxtEuM/LLkObvP3YWaBbv72VlD1mcunTZl5S2hT/KGkS6fTDG+2bkvKli5oXNHuQUJ+pc=,iv:cDPuUxiU1tlTuQbZv350Vne04xIdMOvUvnFgJaZlce4=,tag:xJ0LONZxkEMnK4outabyWQ==,type:str]
     RADARR_IP: ENC[AES256_GCM,data:w0MWj/FL0vawwer2Hfo=,iv:pAjgiS5ps07aruNZMyHmx0PyQdaeW2PrAo1fv2ZxXds=,tag:TagRLLIxyFQzTyqS4aD7Ng==,type:str]
     RADARR_API: ENC[AES256_GCM,data:WOMtHV6vFrd+as1KSnxj3ZBIZE/yJlSof3ihB29hdjY=,iv:X0Ma6jmbZ4EUOwgHS9BeW7v4J/dO/9j/aoT0ym1XkCw=,tag:S4RMnyHUUY6UV17r24JYnA==,type:str]
     SONARR_IP: ENC[AES256_GCM,data:ROAYtzO0RqIZ+2lK60k=,iv:Ud4bHrI4jGnoXf3ZqqZAyXU2B8XJDcjWgBPUO0H6mpo=,tag:wyQvpt2rauv787vsb5OvmQ==,type:str]
@@ -87,11 +87,11 @@ data:
     KAPOWARR_IP: ENC[AES256_GCM,data:0uSLbD6t+7LXLVYO4xI=,iv:uCYA8WzfU5OjzI7YJX3pOwELQ/EQMYYd7B747ookZMI=,tag:Csrz0gkwZwtr8ZUb023YWw==,type:str]
     #ENC[AES256_GCM,data:BvWwp9J5mipNEonoXSpfRlbF+HPwQxklnrjv168l,iv:hp55X5RDjeNRjxrt5VvznR5qAVZMfUuuk8W6o3CiaCQ=,tag:0tVDobbQED3xJfcT6nyO4g==,type:comment]
     TAUTULLI_IP: ENC[AES256_GCM,data:+J8v8UNy+HhCZSmfSms=,iv:pmxAAHES+kNBa9h93QJ8u0pWU27Mdxhas5KnfAW/y8k=,tag:S/++z1YCQA3BBHPYfiwFLA==,type:str]
-    TAUTULLI_API: ENC[AES256_GCM,data:w49s7wVkMvir0IuJcCUSyOX/syaECfVjTyBDg5Khj4A=,iv:/Gt16BAPhbNyXPLPgEhbcw5ojhbxzwuGvXD8DoFWiK0=,tag:1U8Pbz3p+riXRgg0Gm350g==,type:str]
+    TAUTULLI_API: ENC[AES256_GCM,data:l0nmF9z/Pd4rsxamnZtTHyPGwvM07v447BcqZpxg7D4=,iv:7/7MoWIhxvVBXbBWdlX9Pt91ZrUmEp223zwkXP0g9lo=,tag:F0BeUp8a8wnYOhztj1xu5w==,type:str]
     BAZARR_IP: ENC[AES256_GCM,data:YTbD27lEyg33wtmY5Aw=,iv:gdh1eKgZB9c5nRg34THoatg6q+1RhBwBfmPUQy62Zq0=,tag:gxEvbeYbDyUBq7EVK+sRPg==,type:str]
     BAZARR_API: ENC[AES256_GCM,data:dVwhCgl4FxYp80LXUahmCbNmhtcMFJRhAdUHOSC+Ib4=,iv:biZ4ZfdBjDifmYhoxhlBRPxoL+Is3UZ0DtNVtREEm2c=,tag:RijINyAT0c4VQfAJT4QDOQ==,type:str]
     TINYMEDIAMANAGER_IP: ENC[AES256_GCM,data:Xa4P9xh88+NTWeo1n0c=,iv:ke1aWLuEgza7Ov5XvjXzSQQXdXM7JHSzr7tspNdoaq4=,tag:vPQmX4JeUx8Vs5yZKUg57A==,type:str]
-    #ENC[AES256_GCM,data:2jmUbhwTI6th00FfTmQ4ag==,iv:6BCnFa3c09CBrXBlZneJ3moHx3X23yvWLhq0E0J0V7I=,tag:oPVJiktpt9uz5cfdix5Agg==,type:comment]
+    #ENC[AES256_GCM,data:B9cW78KMvtYXenBqal9LVQ==,iv:s78hp0GBRW6YXmOY9ufx4s0HWqkDt0AY46ZlRtNiOlU=,tag:zTmRVN2pV/bEwnnCzH+Ykg==,type:comment]
     TANDOOR_IP: ENC[AES256_GCM,data:UlCzxi/LJOJUX2N5tHc=,iv:XZ3/awC7R6e+wsSu1qCblUlUyneqb7a0iHQqlKhOBJw=,tag:PDvlh/2tVByjz9M760ujzw==,type:str]
     CALIBRE_IP: ENC[AES256_GCM,data:R1G+VcsCg/xEz1G7sNI=,iv:+iw6LN/d/G9+Mdnt69nlINCxMHNhIYaapRIQ2wsAMQw=,tag:FAOi9dobpDp7/Bn7dhSNiQ==,type:str]
     CALIBRE_WEB_IP: ENC[AES256_GCM,data:mFn7Xnadn9jviUz/+GE=,iv:zcTGXObGhtzVB1dPyXaWsocGzRKj163OLU+3FmClVBE=,tag:ZhAnQiePCjBQ6jTbH1MivQ==,type:str]
@@ -105,7 +105,7 @@ data:
     RECYCLARR_IP: ENC[AES256_GCM,data:QdgbSPcvjlu2P6qYobE=,iv:WlfKC5XvThlc6Z581CsEk6EjF1xG0+LT9TYJbLAruxc=,tag:AelI0ZYNHdaZJI/jMEJiaA==,type:str]
     FLARESOLVERR_IP: ENC[AES256_GCM,data:nYjq8lGbo9RUbV4ZqcM=,iv:kaD8ZAojhyUC2PXzohrW6ktAb7+upjUXEjxzqaE1hc4=,tag:yY+33D8Kc67wAnZhoo9KNw==,type:str]
     DISCORD_TOKEN: ENC[AES256_GCM,data:HyxOCozQadYK9Y9sZtI6yT7yi4bqb7AKTl8Crks+agLbjMDJLSdhswiJo/99vuN+G7J60cAFdIIuZJ9YiVEjl9DIoYjYZrzS1y0AiOWMxCD5Xhjq22AC,iv:1O1bNEpFD1Qew621Ssq+Sou3QqYr3KCNoEn6Z4ttR70=,tag:H8j1EWA7cN5UC/BnPHnZ3w==,type:str]
-    #ENC[AES256_GCM,data:VXSb0HbWSNUqo785gw4zeg==,iv:FRs4DhFF3xu8GDq6lGoD6qa24mnpmjcyvJ9S/0vop8c=,tag:uYFswY8eWYCXkr6h8YRD6w==,type:comment]
+    #ENC[AES256_GCM,data:oFiiQJ8uwdjtKRUici1/qw==,iv:vcRBuc+JS6fy9EypblommiKvH+vsREres1Rjba83qsU=,tag:k2a2QqUduPPZTVkj8vOXKA==,type:comment]
     READARR_IP: ENC[AES256_GCM,data:8w5IpUsbIJpvAJ+8BUQ=,iv:QL1ZMC+XO3GIoTyzK0UvDAhOOSQVHkV5gRO3zZrkhJ0=,tag:WNghsVxpu8bGbfWGo6nYuw==,type:str]
     READARR_API: ENC[AES256_GCM,data:QFXcZyI7rYSPlhyfK41B48KxhSAypUYjWiAjzVZtvaw=,iv:7XUsdDA0vZ/O2OuKC0YtPOQm1RqZdWixw7AM8njxKXM=,tag:pRcgXPiNe2vcJ5atLsiUeg==,type:str]
     #ENC[AES256_GCM,data:LT18U97mWtliuM1hErpP++90xg==,iv:/MFu11ApACylO5wcScO8rgcQq1eHvxcclIq0LmGSpzk=,tag:lfkGxEBjaY3tZALxmnskeg==,type:comment]
@@ -190,6 +190,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
     encrypted_regex: ((?i)(displayname|email|pass|ca|id|bootstraptoken|secretboxencryptionsecret|secrets|secrets|password|cert|secret($|[^N])|key|token|^data$|^stringData))
-    lastmodified: "2026-05-27T18:18:33Z"
-    mac: ENC[AES256_GCM,data:Q/wX9Zk2u32qlTsDr+D316LYQRRBL24q3jqvSVUtWRaxYihZbzRQh2p/0rYcBLqEGl811eHIHFqC2atStSK1S5+IAPsjCVYkusJT+WF6c6lWp4k1r45zlCOZOBq7RHVDnYdqTwNywwiRY/GKX2YRTqM38DoYt8tKXUNIGSITXzU=,iv:1oewcF5kSH6CHWPOc03xHrzhqifXyuKzv5KQL93wuDU=,tag:WAktQlzgZt8waz8txP/RaQ==,type:str]
+    lastmodified: "2026-06-09T16:51:43Z"
+    mac: ENC[AES256_GCM,data:/GzXF3Zpf3W34Gn5WpWezXv2Md1YEDIypT/3iXY7EqFyQruUQMJ6CSp0k912eMXbcfKAQdf8dcZkLHWKE0ukBO6x48pZd+5p6rnKIbZ7xR0HcrIFlhtS2BxBVvQF73xQgMy04D8iOTlzOiFqxvDCViltIdKTTl9dQF5grKWDU6U=,iv:CgbFCz/JeMLgQJYV1WbK6fSdfo5I04KcRF2yYjFK//w=,tag:Hqj3QWJtUMw7N0Y7jjDFIg==,type:str]
     version: 3.13.1


### PR DESCRIPTION
## Summary
Three API keys had drifted between `clusterenv.yaml` / `clustersettings.secret.yaml` and the live values in the running pods. The other 14 `*_API` vars all matched — no churn there.

## Drifted (refreshed from cluster)
- `TAUTULLI_API` — from `/config/config.ini`
- `PLEX_API` — from `Preferences.xml PlexOnlineToken`
- `OVERSEERR_API` — from Seerr's `/app/config/settings.json` (Overseerr→Seerr migration preserved the existing key, but the envvar had drifted earlier)

## Verified clean
SONARR / RADARR / LIDARR / LIDARR_FLAC / LIDARR_LIZ / READARR / BAZARR / SABNZBD / NZBGET / MYLAR

## Why update both files
`clusters/main/clusterenv.yaml` is the SOPS source of truth, but Flux's `postBuild.substituteFrom` references the `cluster-config` ConfigMap defined in `clustersettings.secret.yaml`. If only the former is updated, in-cluster substitution still uses the stale ConfigMap.

## Test plan
- [ ] Flux reconciles
- [ ] Tautulli widget on Homepage shows live data
- [ ] Plex widget on Homepage shows live data
- [ ] Seerr widget on Homepage shows live data
- [ ] No exportarrs / homepage widgets going red

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated encrypted configuration values in cluster environment settings.
  * Refreshed encryption metadata timestamps and validation parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->