### PR TITLE
feat(homepage): wire 4 previously-disabled widgets (lidarr-flac/liz, ollama, searxng)

### DIFF
--- a/clusters/main/kubernetes/apps/media/lidarr-flac/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/lidarr-flac/app/helm-release.yaml
@@ -86,7 +86,9 @@ spec:
             icon: ""
             name: Lidarr FLAC
             widget:
-              enabled: false
+              custom:
+                key: ${LIDARR_FLAC_API}
+              enabled: true
         hosts:
           - host: lidarr-flac.${BASE_DOMAIN}
             paths:

--- a/clusters/main/kubernetes/apps/media/lidarr-liz/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/lidarr-liz/app/helm-release.yaml
@@ -86,7 +86,9 @@ spec:
             icon: ""
             name: Lidarr Liz
             widget:
-              enabled: false
+              custom:
+                key: ${LIDARR_LIZ_API}
+              enabled: true
         hosts:
           - host: lidarr-liz.${BASE_DOMAIN}
             paths:

--- a/clusters/main/kubernetes/apps/ollama/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/ollama/app/helm-release.yaml
@@ -74,7 +74,12 @@ spec:
             description: AI Language Model
             group: Lifestyle & Home
             widget:
-              enabled: false
+              # Homepage's ollama widget hits the native Ollama API (port 11434),
+              # not the OpenWebUI frontend (port 10686). Same OLLAMA_IP serves both
+              # via the ollama-api LB service.
+              custom:
+                url: "http://${OLLAMA_IP}:11434"
+              enabled: true
     service:
       main:
         enabled: true

--- a/clusters/main/kubernetes/apps/searxng/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/searxng/app/helm-release.yaml
@@ -82,7 +82,10 @@ spec:
             description: Privacy Search Engine
             group: Tools
             widget:
-              enabled: false
+              # SearXNG is ClusterIP-only; Homepage reaches it via in-cluster DNS.
+              custom:
+                url: "http://searxng.tools.svc:10105"
+              enabled: true
 
     persistence:
       config:


### PR DESCRIPTION
## Summary
Audits found four services where Homepage natively supports a widget but the integration was explicitly set to `widget.enabled: false`. This PR flips them on.

## Changes

| App | Type | Notes |
|---|---|---|
| `lidarr-flac` | keyed | Uses `${LIDARR_FLAC_API}` — already in clusterenv |
| `lidarr-liz` | keyed | Uses `${LIDARR_LIZ_API}` — already in clusterenv |
| `ollama` | keyless | Points to `${OLLAMA_IP}:11434` (`ollama-api` LB, NOT the OpenWebUI front-end on `:10686`) |
| `searxng` | keyless | ClusterIP-only service, reached via `searxng.tools.svc:10105` from `networking` ns |

## Audit matrix

**Already enabled (no change):** sonarr, radarr, lidarr, readarr, bazarr, mylar, sabnzbd, nzbget, deluge, tdarr, tautulli, plex, emby, overseerr, calibre-web, kapowarr

**Deferred — Homepage supports them but needs API key extraction (next PR):** immich, paperless-ngx, tandoor-recipes

**Skipped — no Homepage widget exists:** calibre (desktop server), cwa, it-tools, shelfmark, tinymediamanager, tunarr, roon, stirling-pdf

## Test plan
- [ ] After Flux reconciles: Lidarr FLAC + Liz widgets show queue/library counts
- [ ] Ollama widget shows model list
- [ ] SearXNG widget shows search engine status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled homepage dashboard integrations for Lidarr (FLAC and Liz variants), Ollama, and SearXNG services with custom API endpoint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->