### PR TITLE
fix(homepage): calibre-web URL, ollama NetPol, OOM limit

### DIFF
--- a/clusters/main/kubernetes/apps/media/calibre-web/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/calibre-web/app/helm-release.yaml
@@ -67,7 +67,10 @@ spec:
             widget:
               enabled: true
               custom:
-                url: http://192.168.10.235:8083
+                # Use the templated CALIBRE_WEB_IP from clusterenv (currently
+                # 192.168.10.220). The hardcoded .235 was stale from a prior
+                # MetalLB pool layout and broke the homepage widget.
+                url: http://${CALIBRE_WEB_IP}:8083
                 username: zach
                 password: ${CALIBRE_WEB_API}
     service:

--- a/clusters/main/kubernetes/apps/network-policies/app/ollama-netpol.yaml
+++ b/clusters/main/kubernetes/apps/network-policies/app/ollama-netpol.yaml
@@ -52,3 +52,8 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: goodmem
+    # Homepage widget fetch (model list via ollama-api on :11434)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: networking

--- a/clusters/main/kubernetes/networking/homepage/app/helm-release.yaml
+++ b/clusters/main/kubernetes/networking/homepage/app/helm-release.yaml
@@ -163,7 +163,10 @@ spec:
     resources:
       requests:
         cpu: 10m
-        memory: 128Mi
+        memory: 256Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        # Bumped 512Mi → 1Gi: Lidarr/FLAC/Liz widgets each fetch >4MB JSON
+        # for the artist endpoint; 3 concurrent requests + Next.js overhead
+        # was OOM-killing the container with exitCode 137.
+        memory: 1Gi


### PR DESCRIPTION
## Three issues remaining after PR #4246 synced API keys

### 1. Calibre-Web — wrong widget URL
Hardcoded `http://192.168.10.235:8083` in helm-release. Live MetalLB IP is `192.168.10.220` (matches `${CALIBRE_WEB_IP}` in clusterenv). Homepage was hitting a dead IP → "Host is unreachable".

Fix: use `${CALIBRE_WEB_IP}` so DNS/IP changes track centrally.

### 2. Ollama — NetworkPolicy missing `networking` ns
Cilium enforces east-west pod-to-pod via identity (namespace/pod labels), not ipBlock. The `172.17.0.0/16` ipBlock allow does NOT cover homepage's pod-to-service traffic from networking ns. Homepage was timing out on every `ollama-api.ollama.svc:11434` fetch.

Fix: add `namespaceSelector: networking` to ingress allow list.

### 3. Homepage — OOMKilled crashloop
Container limit was 512Mi. Lidarr/FLAC/Liz widgets each return >4MB JSON (logged warnings). Three concurrent + Next.js overhead = exitCode 137 every ~4 min.

Fix: limit 512Mi → 1Gi, request 128Mi → 256Mi.

## Test plan
- [ ] Flux reconciles all three
- [ ] Homepage container stays Running, no further OOM events
- [ ] Calibre-Web widget shows library count
- [ ] Ollama widget shows model list
- [ ] No regressions on the *arr widgets fixed by #4246

🤖 Generated with [Claude Code](https://claude.com/claude-code)