### PR TITLE
feat(secrets) PR 1/5: scaffold cluster-secrets + substituteFrom entry

### DIFF
--- a/clusters/main/kubernetes/flux-entry.yaml
+++ b/clusters/main/kubernetes/flux-entry.yaml
@@ -20,6 +20,8 @@ spec:
     substituteFrom:
       - kind: ConfigMap
         name: cluster-config
+      - kind: Secret
+        name: cluster-secrets
   patches:
     - patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -37,6 +39,8 @@ spec:
                 name: cluster-config
               - kind: ConfigMap
                 name: upgrade-settings
+              - kind: Secret
+                name: cluster-secrets
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization

--- a/clusters/main/kubernetes/flux-system/flux/cluster-secrets.secret.yaml
+++ b/clusters/main/kubernetes/flux-system/flux/cluster-secrets.secret.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: cluster-secrets
+    namespace: flux-system
+type: Opaque
+stringData: {}
+# Credentials migrated from cluster-config ConfigMap per
+# .claude/plans/2026-06-09-flux-secrets-migration.md.
+# Each entry below is also (still) present in clustersettings.secret.yaml's
+# cluster-config ConfigMap until its corresponding "remove from ConfigMap" PR
+# lands. Flux substituteFrom resolves later sources after earlier ones, so
+# once a var is removed from the ConfigMap, this Secret becomes the sole
+# source.
+#
+# PR 1 leaves this Secret empty on purpose: Flux gains a third substitution
+# source but it contributes zero new keys. No HelmRelease should reconcile
+# differently. (Kubernetes accepts stringData: {} directly — no placeholder
+# key needed.)
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0K0NjN3pJQXBrcG9Nd3ND
+            SzZQNkZMc1Fka0hOS3ZTRVRyemhWN0lHeEdjCjJLOVJpejYzMGdGNmpUUndqZ1ov
+            L3ZhT28vM0V0Y01DTHhTV0QydlE3bzAKLS0tIDMvbmpKa1NtSHI4YmZlME84MGxF
+            OWlxM1dFZnhKeWRKcXdQZ05QVzAwdTAKdI+BaRU90ZsEKrc9h85bGc9VoFX0ya3a
+            v3BRJqOZ4bT8aESK22oVf2LyOSqjkPqZN3yCWYi0kSW2nnTuAXUwXA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
+    encrypted_regex: ((?i)(displayname|email|pass|ca|id|bootstraptoken|secretboxencryptionsecret|secrets|secrets|password|cert|secret($|[^N])|key|token|^data$|^stringData))
+    lastmodified: "2026-06-09T19:55:11Z"
+    mac: ENC[AES256_GCM,data:88j7YIsY0/G/IEtAM7WB6oshL/e67DUMcpMbBmgQBDZaARnSOmlJZUsKYPrJxJulPaxPP6uhA9eFMVVdw1U88NitXdejcg02o70+XLaAiJn1Y8iPJmACBBGeYvRJ27ZZCb51Q0NRPhUtDUjK6bwL7PSxCxXlZOLZc2PxIHOFX44=,iv:jkNMewwOjP6zhNpnmtVumiMusjoil2Ho1JlxFzYAt8A=,tag:lzQFrlWT+yPHSX4Yl40juw==,type:str]
+    version: 3.13.1

--- a/clusters/main/kubernetes/flux-system/flux/kustomization.yaml
+++ b/clusters/main/kubernetes/flux-system/flux/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./deploykey.secret.yaml
   - ./clustersettings.secret.yaml
+  - ./cluster-secrets.secret.yaml
   - ./ghcr-auth.secret.yaml
   - ./flux.yaml
   - ./upgradesettings.yaml


### PR DESCRIPTION
PR 1 of 5 in the Flux Substitution Credentials Migration plan at `.claude/plans/2026-06-09-flux-secrets-migration.md`.

## What

- Creates SOPS-encrypted `cluster-secrets` Secret in `flux-system` namespace (empty `stringData: {}`)
- Adds `cluster-secrets.secret.yaml` to `flux-system/flux/kustomization.yaml`
- Adds `Secret/cluster-secrets` as the third entry in `flux-entry.yaml`'s `postBuild.substituteFrom` list — both the root Kustomization block AND the patched-children block

## Why

Establishes the Secret-side substitution source. PRs 2–4 then move credential variables from `cluster-config` ConfigMap into this Secret one cohort at a time. PR 5 adds Talos `EncryptionConfiguration` + audit policy + deterministic fleet-wide rewrite (per decisions A2+B2 in the plan).

## Expected behavior change

**Zero.** The Secret is empty. Flux gains an additional substitution source that contributes no new keys. Every HelmRelease should reconcile identically.

## Verification (post-merge)

- `flux get all --status-selector ready=false` → empty
- `kubectl get secret -n flux-system cluster-secrets -o jsonpath='{.data}'` → `{}`
- 30 min soak: no kustomization turns Ready=False

## Rollback

`git revert` this commit. The Secret resource disappears; substituteFrom list shrinks back to two ConfigMaps.

🤖 See `.claude/plans/2026-06-09-flux-secrets-migration.md` for the full 5-PR plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new centralized secret resource for managing cluster-level configuration variables used during deployment.
  * Updated the deployment pipeline configuration to reference the new secret resource for variable substitution in Flux deployments.
  * Improved configuration management by consolidating secret-based variables into a centralized resource for enhanced consistency across cluster operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->