### PR TITLE
fix(homepage): drop non-schema 'user' field from Tautulli widget

### DIFF
--- a/clusters/main/kubernetes/apps/media/tautulli/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/tautulli/app/helm-release.yaml
@@ -64,9 +64,11 @@ spec:
             name: Tautulli
             widget:
               custom:
-                url: http://${TAUTULLI_IP}:8181/
+                # Trailing slash removed and non-schema 'user: "true"' dropped.
+                # Homepage's Tautulli widget doesn't accept a 'user' field;
+                # extra fields cause the widget to misrender.
+                url: http://${TAUTULLI_IP}:8181
                 key: ${TAUTULLI_API}
-                user: "true"
               enabled: true
         hosts:
           - host: tautulli.${BASE_DOMAIN}


### PR DESCRIPTION
Drops a non-schema user field that was confusing Homepage's tautulli widget render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined Tautulli configuration for homepage widget integration by removing an unnecessary field and standardizing the URL format for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->