### PR TITLE
feat(homepage-widgets): wire CWA admin / Deluge password / UptimeKuma key

### DIFF
--- a/clusters/main/clusterenv.yaml
+++ b/clusters/main/clusterenv.yaml
@@ -40,7 +40,7 @@ SVCNET: ENC[AES256_GCM,data:hCHyhtea/G7J3Q+Fqw==,iv:H4N+t98TQKIMWXLkhsj7Xs4oLX3C
 BASE_DOMAIN: ENC[AES256_GCM,data:zeu+QKhg35QPVct+qMsbmPzx,iv:+PrX280l0zsbN6JHlA60RaMHhLV0TD0GzD36XZhrXkI=,tag:kqGgCizQdIECN5hvyOAgrg==,type:str]
 BASE_DOMAIN2: ENC[AES256_GCM,data:12Lx1drH1PitfEXC4ck0,iv:HzSZkCfjl7OXAbRWbFB0uplODZvqyvXRJ+y5mI8R8uc=,tag:UDqmyYfm28Ck0SroW2jdKg==,type:str]
 #ENC[AES256_GCM,data:Uye8fLskVxvaQp0zTzUKrBkEg1I=,iv:ujJnzi1O6h0GlUpL1g3pav9ABY0NPviCHJg0if1r6is=,tag:ulDxGxr6q2YPcXDkbrHa7w==,type:comment]
-#ENC[AES256_GCM,data:RbfWXQE8h8j+J1R/lh5f4SLoGg==,iv:aYDzSkbZjog+dh2ZBN/4MphwgOv/Jfls/YMaVOYV3mQ=,tag:75h8qgA1kVaqGUB/Js6Wxw==,type:comment]
+#ENC[AES256_GCM,data:XEytRRYuFNrkdrdFjTX9/Vt9nQ==,iv:4AaARS/VrD9p25BegOfTBlkIUeRg8jMnKk7796en9h8=,tag:IpzMrFEkenLeAGy6EbLxXA==,type:comment]
 NOTIFIARR_IP: ENC[AES256_GCM,data:IcvowHfDtwTrFbHH4sg=,iv:H2MZXGTbfKajCbukpxN6/fup0XXW7FwphEEUMF0cfp8=,tag:O5GC8EgkQfehEZvk/HJH5A==,type:str]
 NOTIFIARR_API: ENC[AES256_GCM,data:sg1Za2DcejVFolS2VMDqKLm3PlALfJJxLFTz1aIIf5Ux714d,iv:TkMJVsUhwmZR+CJBwCBNAW2pN5Wun1PkzuLb9pn3n1A=,tag:RglsLj1RZX9WjeShElClQw==,type:str]
 NOTIFIARR_CHANNEL: ENC[AES256_GCM,data:Uc3nMXqK8IqD1G8JngryaOEyNA==,iv:xRgL0AHYrnZhWbiWoC6QehQXPciV6pEwqpVDv0GVp50=,tag:/tjO+X81FUtA1pDymdEwqA==,type:str]
@@ -85,7 +85,7 @@ TAUTULLI_API: ENC[AES256_GCM,data:zQy0Fiy5cvzQkeRbTyh7xsPBk2mARiL05eZxBGoc7Cg=,i
 BAZARR_IP: ENC[AES256_GCM,data:a4UMzWN8TtwSBXUUfaQ=,iv:lqgyA1ZWd2OGIIA4uza090ITaWdBO3syUidH8tN3o08=,tag:jHf9MTjFUKCHbvm4C00img==,type:str]
 BAZARR_API: ENC[AES256_GCM,data:aNZaxeIS99ajUwXCPQ7yWOWw1jDgvfydW7Omrzi/TaI=,iv:6+cI6YCuXaTWJVrcR4OFdwG3/GA0trN7Vs5HsPijv6c=,tag:iZhdzRmN6dU8fW5HVw5lgA==,type:str]
 TINYMEDIAMANAGER_IP: ENC[AES256_GCM,data:ShKyL3WeH7bHKLlHZgk=,iv:2A3S4AZkk2LpecFq5VoaFLVB13VK0fvjUsVqDea/E98=,tag:lNUQOZSK7iSWd/9LOb1Ing==,type:str]
-#ENC[AES256_GCM,data:bK5V4E9M95+MHqeVe2NHLw==,iv:Gm6IDTc3GCQX/E7jXK1HpZsR4oWI+YAH0i6oPu3zyY4=,tag:0972iRyQxKX3wHvpekufSQ==,type:comment]
+#ENC[AES256_GCM,data:gfqQhBJpInLMsxeADSo0hQ==,iv:gki0SkP8nKd3/LJqyETsxkevoEFO7jk1+yY1nM23lZQ=,tag:pQKv7UBEDx76svPNGcM+2w==,type:comment]
 TANDOOR_IP: ENC[AES256_GCM,data:272/5uIY3Tj9FMiDbPE=,iv:pt+EGmxwg20bpuNpUluuu/Dz8wQ6UcHqkNoZxNYvoJ0=,tag:Hb5jydEDaRF6TvADLzINGw==,type:str]
 CALIBRE_IP: ENC[AES256_GCM,data:23UUHaGA/MsObQsWI64=,iv:XmdzTDbUaq1AKbIT46gP3lwkrTqDdy40aIG6DJoPtIY=,tag:xEQtNnlRNDiCZj7fcNWKRg==,type:str]
 CALIBRE_WEB_IP: ENC[AES256_GCM,data:XrktVkSitVkrTNjDAFw=,iv:BBGuUhWYquSGx4LYmNJQWqrhEIdZK1OlyxwdV5ZsQ2A=,tag:Gx88/dL6ebn0sk9SrbM/RQ==,type:str]
@@ -96,7 +96,7 @@ TDARR_IP: ENC[AES256_GCM,data:pNst1nUU5kzgsHW0u0U=,iv:s+Z6pp7MWAsc2CvYKoaTEzidj8
 RECYCLARR_IP: ENC[AES256_GCM,data:cu6KtITKN8yhCu7eFww=,iv:uXIBhgN++jJDSn6x22p8ZJ2fN7euGOwi6ZAt+/O711w=,tag:tMhy1lHGDxF1GEPwCtumhw==,type:str]
 FLARESOLVERR_IP: ENC[AES256_GCM,data:Ha1ZVAVDG334xl8pNl8=,iv:S0xSkaeC52sIN8zDQwblgolJZ4HZuCBTNGN6kX736Ms=,tag:f2T8Y2L/cs39K8dv6wUVQw==,type:str]
 DISCORD_TOKEN: ENC[AES256_GCM,data:eR+iaDoLH7ek8mwMl2pip4YTTonLlMkZ7Ik6l/K87A6eJZdMxGcmidbl3Rx5B6qqvt3Y5uVt0hQvLSx/YTZSzHvEfCMu7/j/bCNJBVwwqU624TnX8W94,iv:CMyj8xYA0I7aYqnYnX3k4mOCFtQQh9g/Sg7rpF3u/o4=,tag:VO5F8xBHsWjlYKiB+IVh9A==,type:str]
-#ENC[AES256_GCM,data:ef31OameqxSN2dwD3H/68g==,iv:nTROUlvVDJO6NKOuHURv1pJ2hwgzLD89yTUAXBRoRzQ=,tag:4xqRnwYtkvBoDy4wiAXlAA==,type:comment]
+#ENC[AES256_GCM,data:aWxJnR6nVta2yOYTF+wtkg==,iv:AlFlJZH1vfvrFBJo1jAVreqtryUt3O9Hphl5JWVcxcM=,tag:sZ0aRHiHHGPrKxcMfvJX3A==,type:comment]
 READARR_IP: ENC[AES256_GCM,data:JkFeSxiGhJZr083TmIk=,iv:P8AgiFfzAzzMiYvewcPkl2cePz4nqnU+xsdTdDoHAuM=,tag:a1fP53xqzuZC8HDOEUjt6Q==,type:str]
 READARR_API: ENC[AES256_GCM,data:ytd9JJkNGvtD03ruqUiYCjw4fji7lYsw5mC2jc1jaVE=,iv:7JtYc9F4s9S5h6cOwtFBIC2ieRKpVRdtt/EQKutolkg=,tag:HAFOT2TFuZbt2vWrGPt2ug==,type:str]
 #ENC[AES256_GCM,data:XEytRRYuFNrkdrdFjTX9/Vt9nQ==,iv:4AaARS/VrD9p25BegOfTBlkIUeRg8jMnKk7796en9h8=,tag:IpzMrFEkenLeAGy6EbLxXA==,type:comment]
@@ -169,6 +169,8 @@ TRIPARR_APPLE_MAPS_TEAM_ID: ENC[AES256_GCM,data:b0zYrpPJlqvkSA==,iv:mu+vG6aq1VeC
 TRIPARR_APPLE_MAPS_KEY_ID: ENC[AES256_GCM,data:H5iPE9GJslPpBQ==,iv:cjbfc6yZfl4VoMNfciZ4MnYOvEMebC5Ll//DB1O+w+g=,tag:c171z9QDoAkzsD0EH8h5aw==,type:str]
 TRIPARR_APPLE_MAPS_PRIVATE_KEY: ENC[AES256_GCM,data:jAa4hw/UhL+UzIJx0wGtX5OnC2fca4x5TKRR1LyzJlYKxqo8nLx/t24qtVBh1kXVomqDpkQmAONb+izwDN5b/El5ugaSwdI0PFUQWcu3Qy2LvARBGAV6l3vgYZJhWEo56HcRKfxlZnDCtpv2g4KuZITcWDTDkP/9ICdhQyh4dI7mzfjaiP7dcRxf28ah9EVVOXi5+ksoUn+XEJ8EsHeqzMChdt9WhPsSTiaJDviCzn4NfpzkS4s/4SYrG0F0/Wogwu7p/3T2XEXq76vwgbqZPEUAJuQvWCmhqBlQ4gao/ZQdNqexWa82EAb6L2u08I9x1r00Jy5YfGezU8MvRG4ncfOvUG4Lkg==,iv:nwjrZ/YWWOV9lFJE0K5qX0u6wIkSfyrU0FphDhJIJhw=,tag:opptX/KfMYh9QhaXpVmeew==,type:str]
 KAPOWARR_API: ENC[AES256_GCM,data:BmbCOIlM2WN08B55ME/cC5La9RipquBbw+nZh9Vbcbc=,iv:tB+Ivs38iHY3XMkw6DEE+aQDivsUQZEK4JQywTylwYM=,tag:9A1tIUducMNURlY8Ir4TcQ==,type:str]
+DELUGE_PASSWORD: ENC[AES256_GCM,data:AAwD3SbmR4u/6Po1jxukvyZUXQ==,iv:myzKyTAS3U5ngRRw/XgQsmmC3gR46otRRjkN+N6Bw9Q=,tag:iX/LlV8R2ewTAwSlRp724A==,type:str]
+UPTIME_KUMA_API: ENC[AES256_GCM,data:a71hQpoRygR4BB0NvWiuBt186wt5EvGHBe8gUw78GGlvi7oacdRqxV4fVDk=,iv:yC2ucWZTUvF1P7zk429rdy7wJ5e7aSFuc099woE7wKU=,tag:LU9OTfqweYFXPoOk2TH+mA==,type:str]
 sops:
     age:
         - enc: |
@@ -180,7 +182,7 @@ sops:
             Qw4Lt+nuM9OcFo1KPusDuFBvUxcNxnfVbiaftYo838gZfZd5KRTzLQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
-    lastmodified: "2026-06-09T17:43:45Z"
-    mac: ENC[AES256_GCM,data:DPRpPwkLvIciwTDIAJ5kKqWUTKWvV3DFUc7NEnmOh0myhrBu5ZhjGYrVy1siQHiDXetZboZiUBA87Iy0PoWCyp+2WF1GiYqTdy4Oq+LNmufdiQsZaMuvKyligyipTx7ZM59Y0QlzUlThTp0XgZMrICxac06mhcvTNsrb7UdoSYw=,iv:LNcwTH+auvckGprKIt8osZk3zlN+GynGl64boMjqxbk=,tag:Ug7RXiIcb/938u7WehH+TA==,type:str]
+    lastmodified: "2026-06-09T20:45:20Z"
+    mac: ENC[AES256_GCM,data:bspSiu7PR4JHMGfIN/566JyslXbPfRQpptf2HFurT3hDhbgH1ApAZ1Io5hzGA3Jgzr9p/NXLpWAbc0rvakQRSa2IcJYHlWmY9AxL2ZpCCFZ/szn+4kKrx1bAorrYIxAXoiMjLSkhrZFq5vStxfwyrCGt/sPB4SFSO0LwjJ5Xirg=,iv:ymI7j5z7WV37nWXVT9kX0cBo13seE6WRQkskVlIxcbQ=,tag:A1SNwapTZpEWwG5PTORRRA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/clusters/main/kubernetes/apps/media/cwa/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/cwa/app/helm-release.yaml
@@ -75,8 +75,10 @@ spec:
               # creds, swap in a new ${CWA_API} var.
               type: calibreweb
               custom:
+                # CWA's admin user is 'admin' (zachbomb@gmail.com). The
+                # calibre-web-compatible API uses Basic Auth.
                 url: http://${CWA_IP}:8083
-                username: zach
+                username: admin
                 password: ${CALIBRE_WEB_API}
               enabled: true
     service:

--- a/clusters/main/kubernetes/apps/media/deluge/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/deluge/app/helm-release.yaml
@@ -68,6 +68,7 @@ spec:
               enabled: true
               custom:
                 url: "http://${DELUGE_IP}:8112"
+                password: ${DELUGE_PASSWORD}
     service:
       main:
         enabled: true

--- a/clusters/main/kubernetes/flux-system/flux/clustersettings.secret.yaml
+++ b/clusters/main/kubernetes/flux-system/flux/clustersettings.secret.yaml
@@ -46,7 +46,7 @@ data:
     BASE_DOMAIN: ENC[AES256_GCM,data:zhrMcgAvPX3hxtqYYfPkQcLA,iv:o/inuoj6KNTLcQcW0cHh2u9bT0xKVOI1DVITyh+CttM=,tag:sUZG7ZLGU9mUzHzylAJfXg==,type:str]
     BASE_DOMAIN2: ENC[AES256_GCM,data:ryjcVwHPRzsWW4S6p4ek,iv:bg3Fx7rIg0bEijd/dQrIUe18rGDpoHJKQ08sZYVAvd4=,tag:6wkgGjWOfToEAJU9T9qcbA==,type:str]
     #ENC[AES256_GCM,data:sHD+KQUCcor/m5A6+lGj7nzm+Is=,iv:JJqN7LaIT6295xgEJVj/sl7Hx9lfBoOAbdgbf8G4Zlg=,tag:dnZFrqGkwL5PfKS6SOrMUg==,type:comment]
-    #ENC[AES256_GCM,data:bXBv8C4MExKpzhjvg/k/CbyrGQ==,iv:vzOCptRn0DbcxsbDoN9lMYxCzYnJuBrQAFE7yBwJG4E=,tag:13jNiL0oLTHOfnvT49/IjQ==,type:comment]
+    #ENC[AES256_GCM,data:QZt1AKEz9WoxPqCu/PTjlicgzg==,iv:PK909OzTpgKjbo1RqURB7HFTa3qGpWrYsoKJm8OBVP8=,tag:nBokfjKfmQC/CYx0ADo0SQ==,type:comment]
     NOTIFIARR_IP: ENC[AES256_GCM,data:LFlQiChx6z1qiOda6fk=,iv:Stv+ODLNOFIpQwEd/Ktmr9+hCSxCd/MrE14XD9ezG38=,tag:g0Moo+IpEHLI9fQ/y6s63g==,type:str]
     NOTIFIARR_API: ENC[AES256_GCM,data:oJ2eRBw4lTycRID02dEgal/4cDTZti0T/BpWqKOHuRTga447,iv:yABwnfjTgPAYab/47t3YzIM83CIRAFsSwGtkSnO3XZo=,tag:mBQZCyCMMWndhJUwpAc3vA==,type:str]
     NOTIFIARR_CHANNEL: ENC[AES256_GCM,data:koM9mLwq0cYOCp1g6Og1KAV2oA==,iv:s+YamMkmiIf3ccPNMNLLQ6fMMSJG5krxZ2P67eSK29s=,tag:z91SO6LDdvLv7LCHqZELaA==,type:str]
@@ -91,21 +91,21 @@ data:
     BAZARR_IP: ENC[AES256_GCM,data:sWENtS0fqMJ4yfilSng=,iv:T4Io0tEqo8WEAuhvEgL0PSkaUKrHfEKfa+AGO+orHyY=,tag:VXk/qU9xiLuhqv42pOIc1Q==,type:str]
     BAZARR_API: ENC[AES256_GCM,data:UgrNjtKCUn71g3bEVWuQrDciPwB1gU81JhI2PKSbb9g=,iv:Bdi0XCP+FWH8/uo3zV6jorn1DjZiybSfGLHi0OC+xzE=,tag:CpQLS8Pn+oJsNN+gnziElw==,type:str]
     TINYMEDIAMANAGER_IP: ENC[AES256_GCM,data:bN21914dsDmO1p6oCyw=,iv:4BOZsZngk5D/V+vxuZ8ifjgilbWIdLwMzvs2LqUUfGU=,tag:cl4qpuFe90rSQip+j0FeMQ==,type:str]
-    #ENC[AES256_GCM,data:Lni7FV2dTTZSEOm7sWjFzQ==,iv:ooTcsLgZWk3ogsOz0zhFz9RkINOKe9v/Jtju3GzTiwo=,tag:iw/MHj6YVrFMUS1UGQ0/GQ==,type:comment]
+    #ENC[AES256_GCM,data:d3Ab3+j4x80bXVqtDfJ/Vw==,iv:K+3EXGgsI+ZheqDzwI1AZTS3pxqXGM+XPWAQCoU8NO0=,tag:HtFHjHdx9wanccDnccXMbA==,type:comment]
     TANDOOR_IP: ENC[AES256_GCM,data:wiHKk7m73uOHJ9Od1bo=,iv:R1QRBMHlKeNAimPox3hHwCmQ8rpu8s1TZz0j0FEgDh4=,tag:EEjk39aIcattAfUt4plNXA==,type:str]
     CALIBRE_IP: ENC[AES256_GCM,data:H72wfRYvNPdO/jpMT4Q=,iv:kNR4ILjxwqL/H9RaJCdTqb6hyYbkZaj6xHM9gNusR0w=,tag:Tyomhc0uSUq04/Z5HB3hCA==,type:str]
     CALIBRE_WEB_IP: ENC[AES256_GCM,data:D0IhRBGD6XGVWTBlpZc=,iv:1f8zp7GITul3a4Iu+qX8k3EB4UbuQfNQf6LVIkgvVM4=,tag:gdIomSgejmcdOCXKXeMQPA==,type:str]
     CALIBRE_WEB_API: ENC[AES256_GCM,data:C0iEDHOXeYitVcZ32utOL4zaxQ==,iv:QfHBC10mGABSq5vOgB6rvehUfWV8duN9Bd5ot3drVsE=,tag:iRz0V9HjRY1L65u+RcaRbQ==,type:str]
     CWA_IP: ENC[AES256_GCM,data:BXo6TxcxCaZJPi880hA=,iv:uhm3PGdN3EqvP0oK7zwYxxenN/4A1T8KTWOUjSN7WGQ=,tag:rzojVIVeR2J1hnYzAl+pAQ==,type:str]
     SHELFMARK_IP: ENC[AES256_GCM,data:B/vS22K50DZtqpD480U=,iv:uzYeTBUd+TKZPA/rQhdMztqEle/hMkAiBIaBDhZK+Q0=,tag:uh5CyvpJJJiyOZ1YJbO1dw==,type:str]
-    UPTIME_KUMA_API: ENC[AES256_GCM,data:H82BeDCZLS+3uOkR32jNunnobMIBzL+/JxNBfE1xdb8ZWwc0pvbCsn+ZcSw=,iv:dPc3Q2A2kwYHQzf5WJ1YPNDr0kwvnD52PSNtifOR3dI=,tag:glTtsk25egyaSqpfqhxVNQ==,type:str]
+    UPTIME_KUMA_API: ENC[AES256_GCM,data:fVxiPeHtGtBKNdb1/xldpelxhLruxdFFYai8QuXqsB2YcEKLj5ACK1q2WDA=,iv:i5Ep1P2jiHnphrI83gTcp8rFlMca4DqrHAscJjoxhQk=,tag:YRSxCxfq3gfizLD9R0iRww==,type:str]
     #ENC[AES256_GCM,data:2fypb/OjZN5jsUG3lk51LFcBaA==,iv:xg/sjR53EC36gMsWrvqNhgyvJpBX+xvgg6r3iaQmXIE=,tag:uw2kGKfnSch5bllM4IBqow==,type:comment]
     #ENC[AES256_GCM,data:PrD4xBdkBfvsWuMMouVbCFt8S3Sf5SDbNURkCRTM,iv:ZSrGgmyRtSfcUL3k32xZm9MDNiSr5c1zARHoxfI0ERA=,tag:2t9SEE6VNRH4WX2u8VBYlg==,type:comment]
     TDARR_IP: ENC[AES256_GCM,data:/F+Df2b8J1tfq8FoR+s=,iv:75HQnaKIqPcmwVpMe3SRqIXVgImmhwpIK2dnI8HCN6A=,tag:yVJNW83gou9+ZV5zJL+r7g==,type:str]
     RECYCLARR_IP: ENC[AES256_GCM,data:oZ590nrwLozgJemXZM4=,iv:anY/1wPrMdL3HXrumoMwHeXAMZPZitMd+3KbfacH9tA=,tag:QZWfgy7YTif0yUEiwYIzcw==,type:str]
     FLARESOLVERR_IP: ENC[AES256_GCM,data:evGt/k7C/U17znD/SkA=,iv:5/GWwSpgmmeTPJZPLhLRJbi8yhIEWlfdNPd49EzKQc8=,tag:AbMdkrRnaA6CLSEtShWchA==,type:str]
     DISCORD_TOKEN: ENC[AES256_GCM,data:fnpwZk4ylmUejEdMFzQ5m2Vbu3U/yQ+NYnrnccl1P41cIdDdIbpuUYW01Xb5VErnTJ3tqhRlXzZDF6YgpbALpQBCFcT3aqPZ4Njj1vu3oLkIvMZFcHtm,iv:OR530NNruprivg6UPsADTZkIhkdjp8vFRyQpM9jww40=,tag:uJPjLQfvRxxZbagiVtZz1g==,type:str]
-    #ENC[AES256_GCM,data:8exlOX81zakGNBBAOAAhZw==,iv:WfjEgfhIngynkpSJsGX1+58TOXEwdXmaB7TNKdVaci8=,tag:F5aZCmUl3vY8pjAVCJ+2YA==,type:comment]
+    #ENC[AES256_GCM,data:HNPuys/0NI1AigRUo/jXAQ==,iv:J65rCp6uPoxMYc9ZSuqvNOEzYUCjlAQ3lQnD4KGNiI0=,tag:1KZCqQwot1cCSuaP/cBKmw==,type:comment]
     READARR_IP: ENC[AES256_GCM,data:nU3tHqgDLyMCB9WAbqY=,iv:BAnPcPz9OmfOlzCX2Y7WClA0RJfW0X7ZUvxLRUOMkfY=,tag:/WbmyVqq0eSx7JzIQ8jm3w==,type:str]
     READARR_API: ENC[AES256_GCM,data:Oifm2jHpZrbZon7V7439mWRCnSPBYzGMLBFko6oGFnM=,iv:GA9RzpfnH/78rZR6J8pTzp4Ag57BPuyyPNnnlp2A4ZI=,tag:hcVSGcdtSCEqWzLS/DVjzA==,type:str]
     #ENC[AES256_GCM,data:QZt1AKEz9WoxPqCu/PTjlicgzg==,iv:PK909OzTpgKjbo1RqURB7HFTa3qGpWrYsoKJm8OBVP8=,tag:nBokfjKfmQC/CYx0ADo0SQ==,type:comment]
@@ -178,6 +178,7 @@ data:
     TRIPARR_APPLE_MAPS_KEY_ID: ENC[AES256_GCM,data:LKFp4OrWcrcWLg==,iv:S2Xb0epLUaup40+ddePKvJI20bLvV49QSOlCqnFGSlU=,tag:xPuuRvxHQinDidV+vJ91qA==,type:str]
     TRIPARR_APPLE_MAPS_PRIVATE_KEY: ENC[AES256_GCM,data:J6cDnftXAJt+yH8kFzD2vZKTiwuAzQZx1EoJbXYUAijkJScDfc2dsRMh0Xp/AQcfbToRHI90b3OdvwLTkReTUJeJ6pyFATiwymwLceeXtdDpj+uzy9CsUVe3IDvcwYiH/Oi2LUeMM2j7K45fGmEJbcqu6K1BYpyfSacKphBwUanI//kUoKVKKHKNMlwS2WBmVHRsvp1DB8lnLYaYZkmQQzqNClOVdUu+J0M1H//Cq3S3QH5u0sap34BMiTQTOoL+26oM0Q8WUvn9U33X/AxdkvrIgtE/4d9ZnI+YEF660vhdVrzvcpdL8JT+B59sQLNv6td+KGpE3dugPjIX9dAmXlpft03SGg==,iv:XcORqMl7QuMiUaUBXDIqIKmEUT3lG1P1zIKzHuYAZsc=,tag:Clng98SrdI/ecOqms+z6Ow==,type:str]
     CLUSTERNAME: ENC[AES256_GCM,data:YhJ6aQ==,iv:KDUCTB9ZTQCUoIQpkpO8jITeYNooqwGQPL/mJNhRefk=,tag:e+cqxPzEuJyl5bCHBNYAbg==,type:str]
+    DELUGE_PASSWORD: ENC[AES256_GCM,data:7j3TgJhmHhz8B/uAbw0IcWVkWA==,iv:qAl0K89O6+DJv6DqY7sqjqpa8yYjnmgwF82oLZ/yXrE=,tag:zwhuvpG9vvT0VuFRvwxFwg==,type:str]
 sops:
     age:
         - enc: |
@@ -190,6 +191,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
     encrypted_regex: ((?i)(displayname|email|pass|ca|id|bootstraptoken|secretboxencryptionsecret|secrets|secrets|password|cert|secret($|[^N])|key|token|^data$|^stringData))
-    lastmodified: "2026-06-09T17:43:45Z"
-    mac: ENC[AES256_GCM,data:w4sH9XCsoCI2VFd67MHs7ghCSQNLeiSk2BtTNsGRjfjTlrBSqlu9LIVlgq+S/Xh8z7rgfDIAbDbYVKuN5zk3UceQ00G/gvZspBCkC+D9S23L9+BZ168d66IlD/9ePT4qeOZslMDdhAjtKNJ/XIl37wmlZqcolflkkPBPgb/ozgU=,iv:l6cly7krr+im3f3rWnpPpKAETMRVdBeSN2ePz9mqMxg=,tag:KznALOyTTLwaASfRYRPPCQ==,type:str]
+    lastmodified: "2026-06-09T20:45:20Z"
+    mac: ENC[AES256_GCM,data:i1q5X7PtDV95SF2xYKsg4rQd9+sIVgq77K7UpQtFHNxSWleEAiM2ncs28ROaJUgv7NJUCbyGFVKprX/lifQZHa6zdcn24G67/fVceqIXyLtw6pEQpoDgp9kjQaZ/kT0HccOhQErW6ihrztzA8oVCKdc7EpGPOcCMD4egOaiTA+k=,iv:K0psH/rdjk4bwACm2b78WDErFEbqBSsi0aaLZvlCo8U=,tag:+er+HBKE6ezs0uz4LiBRQQ==,type:str]
     version: 3.13.1

--- a/clusters/main/kubernetes/system/uptime-kuma/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/uptime-kuma/app/helm-release.yaml
@@ -80,6 +80,10 @@ spec:
               enabled: true
               custom:
                 url: "http://${UPTIME_KUMA_IP}:3001"
+                # UptimeKuma's homepage widget queries the /metrics endpoint with
+                # HTTP Basic auth (user 'metrics', password = API key). Homepage
+                # converts widget.key to the right auth header automatically.
+                key: ${UPTIME_KUMA_API}
 
     persistence:
       config:


### PR DESCRIPTION
Three widget creds wired through. Restores remaining green badges (CWA, Deluge, UptimeKuma).