### PR TITLE
feat(secrets) PR 5/5: enable Talos etcd encryption + audit logging

### DIFF
--- a/.github/workflows/talos-config-validate.yaml
+++ b/.github/workflows/talos-config-validate.yaml
@@ -28,9 +28,14 @@ jobs:
 
       - name: YAML lint talos directory
         run: |
+          # SOPS-encrypted patches (*.secret.yaml) are binary-ish and not
+          # meaningful to lint — skip them and lint only cleartext patches.
+          PATCHES=$(find clusters/main/talos/patches -type f \
+            \( -name "*.yaml" -o -name "*.yml" \) \
+            ! -name "*.secret.yaml" ! -name "*.secret.yml")
           yamllint -d '{extends: relaxed, rules: {line-length: disable, document-start: disable, truthy: disable}}' \
             clusters/main/talos/talconfig.yaml \
-            clusters/main/talos/patches/
+            $PATCHES
 
       - name: Install talhelper
         run: |

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -10,4 +10,10 @@ creation_rules:
     age: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
   - path_regex: talsecret.yaml
     age: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
+  - path_regex: ^clusters/main/talos/patches/.*\.secret\.ya?ml$
+    age: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
+    # Full-file encryption (like talsecret.yaml). No encrypted_regex,
+    # so the entire patch — including any AES-GCM/signing keys — is
+    # encrypted at rest. Used by PR 5 of the secrets migration to ship
+    # the kube-apiserver EncryptionConfiguration patch.
 ## DO NOT REMOVE: Personal setting go under this line

--- a/clusters/main/kubernetes/system/alloy/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/alloy/app/helm-release.yaml
@@ -81,6 +81,40 @@ spec:
             forward_to = [loki.write.default.receiver]
           }
 
+          // Scrape kube-apiserver audit log mounted from the host.
+          // Audit policy logs Metadata level for secrets — who/when/which-secret,
+          // NOT cleartext credentials. Source: Talos patch audit-policy.yaml.
+          loki.source.file "audit" {
+            targets = [{
+              __path__ = "/var/log/audit/audit.log",
+              job      = "kube-audit",
+            }]
+            forward_to = [loki.process.audit.receiver]
+          }
+
+          // Extract verb/user/resource/namespace/name fields from each
+          // audit event JSON line. Promotes them to Loki labels so we can
+          // query e.g. {audit_resource="secrets", audit_verb="get"}.
+          loki.process "audit" {
+            stage.json {
+              expressions = {
+                verb      = "verb",
+                user      = "user.username",
+                resource  = "objectRef.resource",
+                namespace = "objectRef.namespace",
+                name      = "objectRef.name",
+              }
+            }
+            stage.labels {
+              values = {
+                audit_verb     = "",
+                audit_user     = "",
+                audit_resource = "",
+              }
+            }
+            forward_to = [loki.write.default.receiver]
+          }
+
           // Ship logs to Loki
           loki.write "default" {
             endpoint {
@@ -88,9 +122,24 @@ spec:
             }
           }
 
+      # Mount the host audit log path read-only into every Alloy DaemonSet pod.
+      # Requires the loki namespace to carry pod-security.kubernetes.io/enforce=privileged
+      # because hostPath is forbidden under the baseline PodSecurity profile.
+      mounts:
+        extra:
+          - name: kube-audit
+            mountPath: /var/log/audit
+            readOnly: true
+
     # Run as DaemonSet to collect logs from all nodes
     controller:
       type: daemonset
+      volumes:
+        extra:
+          - name: kube-audit
+            hostPath:
+              path: /var/log/audit
+              type: DirectoryOrCreate
 
     serviceMonitor:
       enabled: true

--- a/clusters/main/kubernetes/system/loki/app/namespace.yaml
+++ b/clusters/main/kubernetes/system/loki/app/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: loki
+  labels:
+    # Required for Alloy DaemonSet to mount /var/log/audit via hostPath.
+    # The baseline PodSecurity profile (default in K8s 1.25+) forbids
+    # hostPath volumes; privileged is needed to allow host log access.
+    pod-security.kubernetes.io/enforce: privileged

--- a/clusters/main/talos/patches/audit-policy.yaml
+++ b/clusters/main/talos/patches/audit-policy.yaml
@@ -18,11 +18,9 @@ cluster:
       - hostPath: /etc/kubernetes/audit-policy.yaml
         mountPath: /etc/kubernetes/audit-policy.yaml
         readonly: true
-        pathType: File
       - hostPath: /var/log/audit
         mountPath: /var/log/audit
         readonly: false
-        pathType: DirectoryOrCreate
 
 machine:
   files:

--- a/clusters/main/talos/patches/audit-policy.yaml
+++ b/clusters/main/talos/patches/audit-policy.yaml
@@ -1,0 +1,48 @@
+# Talos patch: enable kube-apiserver audit logging at Metadata level
+# for Secret access. Logs WHO accessed WHICH secret WHEN — NOT the
+# cleartext body. This is the default safe level; escalating to
+# RequestResponse would write cleartext credentials into the log and
+# require Loki access hardening per the PR 5 plan (Task 5.6 Step 3).
+#
+# Audit log file is mounted into Alloy DaemonSet via hostPath; see
+# clusters/main/kubernetes/system/alloy/app/helm-release.yaml.
+
+cluster:
+  apiServer:
+    extraArgs:
+      audit-policy-file: /etc/kubernetes/audit-policy.yaml
+      audit-log-path: /var/log/audit/audit.log
+      audit-log-maxsize: "100"
+      audit-log-maxbackup: "5"
+    extraVolumes:
+      - hostPath: /etc/kubernetes/audit-policy.yaml
+        mountPath: /etc/kubernetes/audit-policy.yaml
+        readonly: true
+        pathType: File
+      - hostPath: /var/log/audit
+        mountPath: /var/log/audit
+        readonly: false
+        pathType: DirectoryOrCreate
+
+machine:
+  files:
+    - path: /etc/kubernetes/audit-policy.yaml
+      permissions: 0o600
+      op: create
+      content: |
+        apiVersion: audit.k8s.io/v1
+        kind: Policy
+        omitStages:
+          - RequestReceived
+        rules:
+          # Log every interaction with the secrets API at METADATA level
+          # (who, when, which resource — NOT the cleartext body).
+          # To temporarily switch to RequestResponse for a specific incident,
+          # edit this file, then revert when done. RequestResponse requires
+          # Loki access hardening per the PR 5 plan (Task 5.6 Step 3).
+          - level: Metadata
+            resources:
+              - group: ""
+                resources: ["secrets"]
+          # Default: don't audit anything else (limits log volume).
+          - level: None

--- a/clusters/main/talos/patches/encryption-config.secret.yaml
+++ b/clusters/main/talos/patches/encryption-config.secret.yaml
@@ -1,0 +1,40 @@
+#ENC[AES256_GCM,data:g6neTM3JOzw7gsFkL+3YuhFtoyAMEPq5/mKhj9kfxU/i8pTV1YwUHX+CF8QAyRGitWcqzUu5tSNZ75PyN5BSsHTHqw==,iv:umClVcUSACEbSCP1KT8gBDGn0FYUslZ2tNWBYW0M0Ns=,tag:PRCmKjaxXtpvr8L7wzqN5Q==,type:comment]
+#ENC[AES256_GCM,data:71uTO+tPI3C/BIJxIXwL/DiD9mqBxcIBFm7rh6HQu0U+WMscCSKMZVEzivDnj7vDy9IhouAZfQqiE03ZtZaHgI1NU6mj,iv:FYJqhxrLefU3FwSSuJ4hyY+YvVcjjkaTPzdLLDgqUAo=,tag:pSbTajKr6PbwHdmkmLhm2A==,type:comment]
+#ENC[AES256_GCM,data:9EsvLiZk5xNaZPEt9lwgduLCNOkufF9wvwWCpoCUaPFQXS9QcvHGtp/HxG2n+K9Kb8kKfvqzCtwQ/GCgjS7CsQ==,iv:aXJeZYz7embgyqh/jeSC9pNie3EbOLdPwHeoMBDPlmY=,tag:/0jm8oCFnuqycwfAxQkGVw==,type:comment]
+#
+#ENC[AES256_GCM,data:icRueKXnZ8H589MJVqWTenS2NTSKfhz2rdjOsXgUe3dtCxBfhINvd8Q+5ufc1X9Mjg0999s+R2FreU7SoA==,iv:1y3+U8e0OPptQqaN6X3Ebn2twz9XXjlVSBnz+AYjTRg=,tag:GI1CNIjr2x7KX+1qqV2C4w==,type:comment]
+#ENC[AES256_GCM,data:tRZKW2jUtBBe3s+RpeMPBTj1Rp4Bl68BuDlHNNyGOmAdWBb6aOqxD8yDJGIbxZjVKigFyklWwByuIYkFgauVgfY6RXQ=,iv:alWZjnA/6cFck8fqYL15yHmupm0cDhuJx04Wd4/ZS4Y=,tag:ZLGOyVypAz8nzULKSEdCXQ==,type:comment]
+#ENC[AES256_GCM,data:c3MqmEyZj+BV4A+EHzo10ZNzkYuJFWosNRFj9x2y+BO8hvT9h5Q06eQchLE4qXV54huxB3cgpmWZ1KOmW062eo//ipgMtFI=,iv:1NPh9w1hZXRJwJBdz2esAEF/lhIElsffY97So0kyXHo=,tag:NThHoLXK4E1rm/j48anoXw==,type:comment]
+#ENC[AES256_GCM,data:1Sgj++2lphBKS24sC+iUtmXC5hRAtZZFLUZX/qKxVHVZelgQrxNEjXUPTpp2Smx6W5O3ZIjpAhl45FjbW2igUwW27x9V6w==,iv:fIG7iYkQmR4w30G0dScvpiMW70Kr6ov7fEuaUoLoPIM=,tag:yqH9CDquX5nsB8yk8xup2A==,type:comment]
+#ENC[AES256_GCM,data:YE5b3JNaPuR93L8T7UvfNSDxlFD2acMYegWXzt0qQQn1FrZBY5/U1GdyYo7G3roBip6xffEHPfFvTGrLhNlmUEwO90GRdiI=,iv:lPJO4CAkywScs1CgzPy7qyVGXMu5NEbiuhoz0fFLR9c=,tag:xFpCcZp+udkkY8d4MSfMdQ==,type:comment]
+#ENC[AES256_GCM,data:91xc041dwfqXfQz33/2jKcPyUw/u1MBDwulkPprZ9ov3bBNRabUCZWzew/WGVDW95uf2mGtNwtId1G3E3Fp4o+cWrABlbDr6OA==,iv:f45FQdfzKHzTcXqIu+riOfZHxi2HyfUHxNPGfvBKl/Q=,tag:MBH2r/l2Y9Lvwq3pFIFESg==,type:comment]
+cluster:
+    apiServer:
+        extraArgs:
+            encryption-provider-config: ENC[AES256_GCM,data:9jlbCz1Z/FawSU4h9fHMfMEYbDGq43f54si2wJR/syRD1/EBpIk=,iv:wxcWkugbpEPGC/b3tdmXK9RGQGjv19TacMLE4PdyGKs=,tag:HLie37S7qfURfQtU/IZ9eA==,type:str]
+        extraVolumes:
+            - hostPath: ENC[AES256_GCM,data:D3/y16JlY78rVJlRDFrMYvksBPX42oHKPzWp/55fMeBZs7alVbw=,iv:hklwaDzx3mEJAJY9Lf2ZHGOlEKUNPcxfUgBW7m4yY4w=,tag:Pzk63oPuya6ZkH84njJOMg==,type:str]
+              mountPath: ENC[AES256_GCM,data:7Fmkz5wY3WKAj9zor4CeU3h0KDC71P9ck1zOBCaB39ER/jpVHUo=,iv:dY2ufQF0S7UVjS2CKncQwTlY+LSL6xt1pV3nUkbtVuE=,tag:uPiLHU0YWBcNS1/0vsVqnQ==,type:str]
+              readonly: ENC[AES256_GCM,data:CHhjJg==,iv:DueaBGOsC4XfBKRAqLyyi9kK56sptT7ULiPKakrIF08=,tag:anG45YCfWymQdrtxQlfPkA==,type:bool]
+              pathType: ENC[AES256_GCM,data:v0BgbQ==,iv:Y4pU6SOUZ9DE6VnEFXRZ8SYpKEUHz/dtr7tYC4aXhIU=,tag:PKpy2qnxsJO5a3+PocGuWw==,type:str]
+machine:
+    files:
+        - path: ENC[AES256_GCM,data:I1a5HsMUzUhUL7yv/TEceNfNg9y1kHzMsjvtDy5ne1cT+7aymCU=,iv:oM6vKxfyPJmR0asgo46jDSoJyySqs9IPL0GcGeFDB8Y=,tag:QidD6cR2piULy3WeS186XQ==,type:str]
+          permissions: ENC[AES256_GCM,data:WUGc,iv:yzsUr934tngjLfVhUxwj8Wze1X6NPWaWnsuLSvSD63E=,tag:afwliV8GqG3W0RRJza4JBw==,type:int]
+          op: ENC[AES256_GCM,data:k8WbyP+R,iv:8ucyAumDZEcIHxdZ1nIBOuDT6UibSmWaRhEjwMqdUlY=,tag:kyhSnWYG1PiVxFKILu+JBQ==,type:str]
+          content: ENC[AES256_GCM,data:E20V+VHA6tGgxSg48Zl/KF2mETqLVmHxUE1wGXq0pmKMb5kzvgcXDzIhiPUkZfkLTI1OBWg6JiL9fujX++54OzNPnvqUk23iEoTbeTNnT2sy8G57oqJxbdra8XFlb8sZ/UkdelJ1L2un9qTVcC+1aLc0AJCCwBmI3XMPszfGUMSC9QoyUMssHzkplvvu4m2whdSXfVV/b5HZz1feyv/5XHa+qbwpcKd6s0wroH3HA1G0G0lfaV2wEfuFmZjN7CXbucyIlnJndDE9IbcC7kUomNiCK+ld4rkA3wMR0B3AYyX1hShVA9jnn3o+qbXaHMXR5ftphQBfRvDZPR3RoAvLS8kcFNOUdjwDG5PKLiwNtA==,iv:dGeUwIkqgqJUD036V9TOHh2ppnm+WOeB1aO+wrxfD0E=,tag:5+UQHmQ+Qn0VU7pn1kT8aQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArN0dRU1BLQzVzazI5bkJL
+            UmZ0VE02QW1jTEkvWTlzdXB1QmsycDRETjJFCjl5RFdEOXBGc3hSUkU4RlpjWDRQ
+            K1VTYlJsbXg5My9mb0s4eE8rMUhGOUUKLS0tIFU0SU1YUEU4RkpTQVJETktCayt6
+            K3U4WW9aTERZbzZ2YlhZcEhxbGx2MkkKQjPZu8oQIUGLX5JPAHPKhRfVYsxvnZYk
+            W/H6LHm+nzpR2erIk6uITEe/wvihLcRC9enyzZ7016ePK+Tc9vKBRQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
+    lastmodified: "2026-06-09T22:12:51Z"
+    mac: ENC[AES256_GCM,data:fT2Ib+GcB5/ojtlDDJWbasHg0Rr3CabPpxrAT3SOn5jKnSEJQJh1zX6s3xGJ+8mVe4GILd4xG2D6GRPcnbMy3CgpSKW5Q2CtM8VPIuU7Xe6lGiKVLhAnb1Dtc+PWfGIAnchcVQsmP1WGr7gXEt+oj1q2f8D88sRJn3F1UW0WJds=,iv:ofCl22U2Zmy8WfM/ZCH4ZR+JhfnRao9TOJHMFX4NI8o=,tag:X+o110QEAMBxy2O04NYCrQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.1

--- a/clusters/main/talos/patches/encryption-config.secret.yaml
+++ b/clusters/main/talos/patches/encryption-config.secret.yaml
@@ -1,40 +1,39 @@
-#ENC[AES256_GCM,data:g6neTM3JOzw7gsFkL+3YuhFtoyAMEPq5/mKhj9kfxU/i8pTV1YwUHX+CF8QAyRGitWcqzUu5tSNZ75PyN5BSsHTHqw==,iv:umClVcUSACEbSCP1KT8gBDGn0FYUslZ2tNWBYW0M0Ns=,tag:PRCmKjaxXtpvr8L7wzqN5Q==,type:comment]
-#ENC[AES256_GCM,data:71uTO+tPI3C/BIJxIXwL/DiD9mqBxcIBFm7rh6HQu0U+WMscCSKMZVEzivDnj7vDy9IhouAZfQqiE03ZtZaHgI1NU6mj,iv:FYJqhxrLefU3FwSSuJ4hyY+YvVcjjkaTPzdLLDgqUAo=,tag:pSbTajKr6PbwHdmkmLhm2A==,type:comment]
-#ENC[AES256_GCM,data:9EsvLiZk5xNaZPEt9lwgduLCNOkufF9wvwWCpoCUaPFQXS9QcvHGtp/HxG2n+K9Kb8kKfvqzCtwQ/GCgjS7CsQ==,iv:aXJeZYz7embgyqh/jeSC9pNie3EbOLdPwHeoMBDPlmY=,tag:/0jm8oCFnuqycwfAxQkGVw==,type:comment]
+#ENC[AES256_GCM,data:DJmUa1jqEuy+gkPbwKIt/8QnluWpFjsLQcHhDC3ccqbRaZ8dPsKBp22+8IRyPn2C7WbBAakaOQk02wrbBCn/mbZ7wQ==,iv:wInRshEYiw9Ug86j8cTfkXNCAhE8SXA2pqRXO0ZMyBs=,tag:d0VWfyqoRZrjGZaX8zMDzg==,type:comment]
+#ENC[AES256_GCM,data:F/jwXReduf/LtEtqiFRp2b8vUNWIRus7I8on5n3Isb+Jy0ueQU0MKuPGq85kOUDAk6yAf/cCLMhBvKrZeVRRkqdTDMc1,iv:OBWev5hLFZVf0zUEl1a1KS2HlpTxwHKakTTzw5xDKD8=,tag:ovi6i7MpqZHx2s1PMCHf9w==,type:comment]
+#ENC[AES256_GCM,data:FmXIjU4w3rwUFZKtUlkGOO4yjujexnOMf1X7q02SNaFs1cOgePCUn9Js+TYS02YYWtI29qZpxMcB5xDViGXL7w==,iv:xchJLyvIRjQHIdjx7U96dUsVV1oLoxo5E/ZKXmJjf+s=,tag:Q7L1F+0LJgP68iX7X0W1tA==,type:comment]
 #
-#ENC[AES256_GCM,data:icRueKXnZ8H589MJVqWTenS2NTSKfhz2rdjOsXgUe3dtCxBfhINvd8Q+5ufc1X9Mjg0999s+R2FreU7SoA==,iv:1y3+U8e0OPptQqaN6X3Ebn2twz9XXjlVSBnz+AYjTRg=,tag:GI1CNIjr2x7KX+1qqV2C4w==,type:comment]
-#ENC[AES256_GCM,data:tRZKW2jUtBBe3s+RpeMPBTj1Rp4Bl68BuDlHNNyGOmAdWBb6aOqxD8yDJGIbxZjVKigFyklWwByuIYkFgauVgfY6RXQ=,iv:alWZjnA/6cFck8fqYL15yHmupm0cDhuJx04Wd4/ZS4Y=,tag:ZLGOyVypAz8nzULKSEdCXQ==,type:comment]
-#ENC[AES256_GCM,data:c3MqmEyZj+BV4A+EHzo10ZNzkYuJFWosNRFj9x2y+BO8hvT9h5Q06eQchLE4qXV54huxB3cgpmWZ1KOmW062eo//ipgMtFI=,iv:1NPh9w1hZXRJwJBdz2esAEF/lhIElsffY97So0kyXHo=,tag:NThHoLXK4E1rm/j48anoXw==,type:comment]
-#ENC[AES256_GCM,data:1Sgj++2lphBKS24sC+iUtmXC5hRAtZZFLUZX/qKxVHVZelgQrxNEjXUPTpp2Smx6W5O3ZIjpAhl45FjbW2igUwW27x9V6w==,iv:fIG7iYkQmR4w30G0dScvpiMW70Kr6ov7fEuaUoLoPIM=,tag:yqH9CDquX5nsB8yk8xup2A==,type:comment]
-#ENC[AES256_GCM,data:YE5b3JNaPuR93L8T7UvfNSDxlFD2acMYegWXzt0qQQn1FrZBY5/U1GdyYo7G3roBip6xffEHPfFvTGrLhNlmUEwO90GRdiI=,iv:lPJO4CAkywScs1CgzPy7qyVGXMu5NEbiuhoz0fFLR9c=,tag:xFpCcZp+udkkY8d4MSfMdQ==,type:comment]
-#ENC[AES256_GCM,data:91xc041dwfqXfQz33/2jKcPyUw/u1MBDwulkPprZ9ov3bBNRabUCZWzew/WGVDW95uf2mGtNwtId1G3E3Fp4o+cWrABlbDr6OA==,iv:f45FQdfzKHzTcXqIu+riOfZHxi2HyfUHxNPGfvBKl/Q=,tag:MBH2r/l2Y9Lvwq3pFIFESg==,type:comment]
+#ENC[AES256_GCM,data:UF3RQSfs7Iz352vkWvmaMZAavW82OoYXHRWjmGkdsRLIYy0fDlfKprIMRrAfAiJDLCSRrozwoReoAkKjeA==,iv:mL8eEylb2Vj83HEIqu933agJ7iXMbkHOkPp5CUAC4cI=,tag:ovnlSCPZyIi8H6cHYQ1HlQ==,type:comment]
+#ENC[AES256_GCM,data:Zf+WredsadwXHuHtzbb0lqf4Udw42rbE8qPqka4HSqzuYorCISKRgmdG8xbwvnfoNihr0dIbC4kuHI9LvyzdYM1HdSA=,iv:U1KDBFzs8UhbIe5hcVZxZ4u3jMN2qh4/3na0sXSxZnM=,tag:j86ciAYRbqiKYL+2o0p4KQ==,type:comment]
+#ENC[AES256_GCM,data:vfGlsQaP5EuXF8GUGT47CJIE770hL5JyysbPg7SRLkmjotKX3wt+/b7IkWf4HEuAOUxXLN6Ag2u1ghgJZ9PUt+hZ5oAIPgg=,iv:Sz5vD4OhGJr0UR6G7wZPQgMq67gylx1MLaeGZrQFjcY=,tag:kNJtFmOhSW90UTtTrVG4cQ==,type:comment]
+#ENC[AES256_GCM,data:j6Vo/pZVptxUzM8+2VBgiyoRyxjVc9UYS2/X455HYhvSaO3rYPw11KUzwrC/0i9oSRhzIwDHeorVCzhQHImL4J1ZI+sZaA==,iv:uJaftAtOtvdhss8NKxQBKUXkeMxeXENeOMuzqCU5jn0=,tag:CKHiWWwOksxV5inr2z7j4Q==,type:comment]
+#ENC[AES256_GCM,data:tGnzq3bRGKoUWyp7QitKPI/NOCK21YlINMwaMIeuG6mznnmxHfC3LxkPvEz5yTocDH36L5sIjdtFpNUhc7pWfs/1GZCEjfA=,iv:WmhWrRgr1RaaooXCzbtwVO2c7bGRsn051sEgeicodJ4=,tag:QbWzDwi9qIgFLInfzSQJcQ==,type:comment]
+#ENC[AES256_GCM,data:23HDUavkuhM0Zk2z2p1YELV/wtZL7zvH08CH81SOxrVMSmu9pz62rYTV7Sku0B+91jv9SQoQhk60TeJ3e++2uQyfuH6RVlwB9A==,iv:0nyKtnSWvDcOo651vjcHB7FFT4fSfgwi/vXwjoh6+9Y=,tag:Nln2dxOeYYs/ncHxg/0JCw==,type:comment]
 cluster:
     apiServer:
         extraArgs:
-            encryption-provider-config: ENC[AES256_GCM,data:9jlbCz1Z/FawSU4h9fHMfMEYbDGq43f54si2wJR/syRD1/EBpIk=,iv:wxcWkugbpEPGC/b3tdmXK9RGQGjv19TacMLE4PdyGKs=,tag:HLie37S7qfURfQtU/IZ9eA==,type:str]
+            encryption-provider-config: ENC[AES256_GCM,data:PoGxVvjS8P3E+pZfE5Vo8JuZawET9Tyq11fFL3pjcvoc2lf0aec=,iv:stWbj8vfzeGDUNc8uH7I7gC42wPsY/v9C9c34B9ttVU=,tag:uaXbYzHoSGdXUB8TPJr6MQ==,type:str]
         extraVolumes:
-            - hostPath: ENC[AES256_GCM,data:D3/y16JlY78rVJlRDFrMYvksBPX42oHKPzWp/55fMeBZs7alVbw=,iv:hklwaDzx3mEJAJY9Lf2ZHGOlEKUNPcxfUgBW7m4yY4w=,tag:Pzk63oPuya6ZkH84njJOMg==,type:str]
-              mountPath: ENC[AES256_GCM,data:7Fmkz5wY3WKAj9zor4CeU3h0KDC71P9ck1zOBCaB39ER/jpVHUo=,iv:dY2ufQF0S7UVjS2CKncQwTlY+LSL6xt1pV3nUkbtVuE=,tag:uPiLHU0YWBcNS1/0vsVqnQ==,type:str]
-              readonly: ENC[AES256_GCM,data:CHhjJg==,iv:DueaBGOsC4XfBKRAqLyyi9kK56sptT7ULiPKakrIF08=,tag:anG45YCfWymQdrtxQlfPkA==,type:bool]
-              pathType: ENC[AES256_GCM,data:v0BgbQ==,iv:Y4pU6SOUZ9DE6VnEFXRZ8SYpKEUHz/dtr7tYC4aXhIU=,tag:PKpy2qnxsJO5a3+PocGuWw==,type:str]
+            - hostPath: ENC[AES256_GCM,data:JHl3L7WNfveIg6MpeHQihvWvxpvtj5qW7wCrX44x8IcaiPn/sxY=,iv:ai9P+DWsZRz211jV+zzYoyoxdB1pbTvUtv2zvvPB/gk=,tag:i8h4PzhVhLJKq3eCvnSSCw==,type:str]
+              mountPath: ENC[AES256_GCM,data:1TF02SW3dYeM13stuvfvwjsi7FR0vL227Wvsgc4ZSDJoXg52rHk=,iv:YPsPr5I6gs0Jz0RKUzcZIqglqslIsMl8hiQgrgQWdPQ=,tag:Ng0hMxkgdtgA/fHKsokeLg==,type:str]
+              readonly: ENC[AES256_GCM,data:XHgp+Q==,iv:IV6evEViEQTlneUv9L3MdPtWp2BS2pZlMLSuqdj2HrE=,tag:rQ6AoyBhhHrs8knZp50vOQ==,type:bool]
 machine:
     files:
-        - path: ENC[AES256_GCM,data:I1a5HsMUzUhUL7yv/TEceNfNg9y1kHzMsjvtDy5ne1cT+7aymCU=,iv:oM6vKxfyPJmR0asgo46jDSoJyySqs9IPL0GcGeFDB8Y=,tag:QidD6cR2piULy3WeS186XQ==,type:str]
-          permissions: ENC[AES256_GCM,data:WUGc,iv:yzsUr934tngjLfVhUxwj8Wze1X6NPWaWnsuLSvSD63E=,tag:afwliV8GqG3W0RRJza4JBw==,type:int]
-          op: ENC[AES256_GCM,data:k8WbyP+R,iv:8ucyAumDZEcIHxdZ1nIBOuDT6UibSmWaRhEjwMqdUlY=,tag:kyhSnWYG1PiVxFKILu+JBQ==,type:str]
-          content: ENC[AES256_GCM,data:E20V+VHA6tGgxSg48Zl/KF2mETqLVmHxUE1wGXq0pmKMb5kzvgcXDzIhiPUkZfkLTI1OBWg6JiL9fujX++54OzNPnvqUk23iEoTbeTNnT2sy8G57oqJxbdra8XFlb8sZ/UkdelJ1L2un9qTVcC+1aLc0AJCCwBmI3XMPszfGUMSC9QoyUMssHzkplvvu4m2whdSXfVV/b5HZz1feyv/5XHa+qbwpcKd6s0wroH3HA1G0G0lfaV2wEfuFmZjN7CXbucyIlnJndDE9IbcC7kUomNiCK+ld4rkA3wMR0B3AYyX1hShVA9jnn3o+qbXaHMXR5ftphQBfRvDZPR3RoAvLS8kcFNOUdjwDG5PKLiwNtA==,iv:dGeUwIkqgqJUD036V9TOHh2ppnm+WOeB1aO+wrxfD0E=,tag:5+UQHmQ+Qn0VU7pn1kT8aQ==,type:str]
+        - path: ENC[AES256_GCM,data:vm1UhFiU0yU80QAFESeTekF55cfG8JST3wLmaWC7mSojQ8yTZNk=,iv:yH3MY3+a3lgx7FE7vrWKOBL6FjLMHc0Bg0ysj/av4mw=,tag:5kWXT4bEJE+wOzysGyQohA==,type:str]
+          permissions: ENC[AES256_GCM,data:Lemv,iv:4j6+nz7wB/WfaxvEuneeCiyLagPxgVUEjh5ntb0MBCs=,tag:MQw2f3VJ8IdiwL6PBYYHCQ==,type:int]
+          op: ENC[AES256_GCM,data:qPW+FS+b,iv:DoFjRartZecTJrpABqIe7dHstyZekapcTjGJpDEdqXQ=,tag:gu8MwegASf3IxjT+Y1lRQg==,type:str]
+          content: ENC[AES256_GCM,data:khS8QY2bUuQyXQrlzJlDuVY/GQbKMcWEdsprPtptx3PLszXBjlomZDiNNSqpG8Ub3sadVKHv+1dS1lmv8JxtIjL0xnm2rGPu4K/wV9Vc4YhX5X568P09fxA4/VJUlBznTh2F3v8invwlZQPhfAG5ZpiXRmA0XgOeZCIh4YAVhDxRwxQSEHn/8XOv3lMkt2oi9J16io6hbdvAg7kyaUPg6kEkHaznw0KPCIYjzYsNk0xOXeu5YpKIwyVSFDR0JSXPitvfD6EMHkPgU56E9qfADyHxj+4R4EVPY9cv8Etpg81Cfu7fwkaBXxxWfJZ0K+EPwgkgIpKLddZADVdz9sWm2FxaS4bF8JWY9mOLSjaClQ==,iv:4aaTdq8XSVOJ8OByv7PsVXuw4Yvzy7TLg+fOItnQNj8=,tag:aZh+1GCj1gcahC9wqLpWVA==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArN0dRU1BLQzVzazI5bkJL
-            UmZ0VE02QW1jTEkvWTlzdXB1QmsycDRETjJFCjl5RFdEOXBGc3hSUkU4RlpjWDRQ
-            K1VTYlJsbXg5My9mb0s4eE8rMUhGOUUKLS0tIFU0SU1YUEU4RkpTQVJETktCayt6
-            K3U4WW9aTERZbzZ2YlhZcEhxbGx2MkkKQjPZu8oQIUGLX5JPAHPKhRfVYsxvnZYk
-            W/H6LHm+nzpR2erIk6uITEe/wvihLcRC9enyzZ7016ePK+Tc9vKBRQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBycTRkV0xNNmlPRWF1dW5I
+            OUtHVkUxMTl3amJqRVk5dW1vZnlXVVhKaW04CndYVERRMy9TNnAyK05MbUlpdWRJ
+            SUg0dExaNkNUS3l6cWY3V00zUTRLaEkKLS0tIHZGUTdtS3JBTTN6Rm1OMnRZR1Qv
+            eEpjUE5NSzdQdG5jbmNkZ2wxUGFQVjAKpuO3DNDzKyB99/VZe5Ifz0W2d8e2f12p
+            0vrHW6yM4nYjGrbfFKjUnE0gE8OX80mNmVlV6Ds7VFiGRE/fBHrJqQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
-    lastmodified: "2026-06-09T22:12:51Z"
-    mac: ENC[AES256_GCM,data:fT2Ib+GcB5/ojtlDDJWbasHg0Rr3CabPpxrAT3SOn5jKnSEJQJh1zX6s3xGJ+8mVe4GILd4xG2D6GRPcnbMy3CgpSKW5Q2CtM8VPIuU7Xe6lGiKVLhAnb1Dtc+PWfGIAnchcVQsmP1WGr7gXEt+oj1q2f8D88sRJn3F1UW0WJds=,iv:ofCl22U2Zmy8WfM/ZCH4ZR+JhfnRao9TOJHMFX4NI8o=,tag:X+o110QEAMBxy2O04NYCrQ==,type:str]
+    lastmodified: "2026-06-09T22:16:03Z"
+    mac: ENC[AES256_GCM,data:73qS9IdcnUuf+ag01/nGhwQd5roiWhXAHRwjRYIef712mTdZWFZq6J61ZW2MN41LGyaHu6gd9rIxI+Aq9fJEjUAbJL7deLAFoJNsnA85eJ82cZxRbnbgIqPtU8r8DocYi3qkkhGlcLkDhf2Grj19gzaJn41lzZH8YvZgrff2Upc=,iv:ggzrFFiawchhIHuTJbGbZT4LJsEwRDZWUhpJpXXqa0Q=,tag:+4QtznwezGygwi42Vx90Ew==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/clusters/main/talos/talconfig.yaml
+++ b/clusters/main/talos/talconfig.yaml
@@ -45,6 +45,8 @@ controlPlane:
     patches:
         - '@./patches/controlplane.yaml'
         - '@./patches/nvidia.yaml'
+        - '@./patches/encryption-config.secret.yaml'
+        - '@./patches/audit-policy.yaml'
     kernelModules:
      - name: nvme_tcp
      - name: vfio_pci


### PR DESCRIPTION
## Summary

PR 5 of 5 in the [Flux Secrets Migration plan](.claude/plans/2026-06-09-flux-secrets-migration.md). **Code-only changes.** Apply steps are intentionally deferred — see "Apply sequence" below.

After PR 2–4, every credential lives in the SOPS-encrypted `cluster-secrets` Secret instead of the cleartext `cluster-config` ConfigMap. This PR adds the **second layer**: kube-apiserver-level encryption-at-rest for Secret bodies in etcd, plus audit logging for Secret access.

## What this PR ships

| Layer | Change |
|---|---|
| **etcd-at-rest** | New SOPS-encrypted Talos patch `clusters/main/talos/patches/encryption-config.secret.yaml` — adds `--encryption-provider-config` to kube-apiserver. Providers ordered `[aesgcm, identity]` so existing cleartext-stored Secrets stay readable while new writes go through AES-GCM. |
| **`.sops.yaml`** | New rule `path_regex: ^clusters/main/talos/patches/.*\.secret\.ya?ml$` (full-file encryption, no `encrypted_regex`). |
| **Audit policy** | New patch `clusters/main/talos/patches/audit-policy.yaml` — `Metadata` level on `secrets` (who/when/which-secret, NOT cleartext bodies). `RequestResponse` is opt-in only. |
| **Loki/Alloy** | Alloy DaemonSet gets a hostPath mount for `/var/log/audit/audit.log` + Loki source/process pipeline that parses each audit event into `audit_verb` / `audit_user` / `audit_resource` Loki labels. Loki namespace gains `pod-security.kubernetes.io/enforce=privileged` (required for hostPath). |
| **CI** | yamllint excludes `*.secret.yaml` in `talos/patches/` (SOPS binary blobs aren't meaningful to lint). |

## Apply sequence — DEFERRED (requires hands-on supervision)

Two reasons not to apply autonomously:

1. **Local `genconfig` tooling is wedged:** `forgetool` 3.0.2 ships `talhelper ≤3.1.5` which rejects Talos v1.13.4; `clustertool-new` requires `HEADLAMP_IP` (not in clusterenv). Same blocker hit during the v1.13.4 Talos upgrade — known workaround is the existing JSON-patch live-edit workflow.
2. **Single control-plane outage window:** `talos apply` restarts the apiserver static pod (10–30s `kubectl` outage). Worth driving in person.

When ready, run:

```bash
# 1. Generate Talos config
HEADLAMP_IP=192.168.10.250 ./clustertool-new genconfig
# (or bump local talhelper to >=3.1.10 if you prefer forgetool)

# 2. Apply (apiserver pod restarts; brief outage)
./clustertool-new talos apply

# 3. Wait for apiserver
until kubectl get --raw=/livez >/dev/null 2>&1; do sleep 5; done

# 4. Force-replace cluster-secrets so it's encrypted via the new provider
kubectl get secret -n flux-system cluster-secrets -o yaml | kubectl replace -f -

# 5. Verify etcd-side encryption
talosctl --nodes 192.168.10.89 etcd snapshot /tmp/etcd.snap
go install go.etcd.io/bbolt/cmd/bbolt@latest    # if not installed
bbolt get /tmp/etcd.snap key /registry/secrets/flux-system/cluster-secrets | head -c 200
# Expect: starts with "k8s:enc:aesgcm:v1:key1:"

# 6. Fleet-wide Secret rewrite (resolves architectural Decision A2)
#    Script body lives in plan Task 5.4 (Lines 1282-1421).
/tmp/fleet-rewrite-secrets.sh dry-run | tee /tmp/rewrite-dryrun.log
/tmp/fleet-rewrite-secrets.sh apply   | tee /tmp/rewrite-apply.log
```

## Rollback (symmetric)

```bash
# 1. Edit the patch (swap providers to [identity, aesgcm] — identity wins on writes,
#    aesgcm still decrypts older entries)
sops clusters/main/talos/patches/encryption-config.secret.yaml
# 2. genconfig + apply (single-cp will outage briefly)
./clustertool-new genconfig && ./clustertool-new talos apply
# 3. Rewrite everything back to cleartext
/tmp/fleet-rewrite-secrets.sh apply
# 4. Revert this PR
git revert <commit-sha>
# 5. genconfig + apply once more
```

## Doc-review fixes applied

- Talos patch isn't templated through talhelper (round-1 caught the literal-string trap); key is inline in the SOPS-encrypted file.
- Audit policy stays at `Metadata` — `RequestResponse` would write cleartext credentials into Loki, recreating the cleartext surface the migration is trying to eliminate (round-2 catch).
- Alloy `mounts.extra` + `controller.volumes.extra` keys confirmed correct for Grafana Alloy chart v1.9.0.
- Loki namespace gains `pod-security: privileged` label (round-2 catch — Alloy DaemonSet would fail admission without it).
- yamllint scoped to non-`.secret.yaml` files in patches/ (SOPS blobs would fail lint).

## Test plan
- [ ] After deferred apply: `kubectl get --raw=/livez` healthy within 60s of `talos apply`
- [ ] `bbolt get /tmp/etcd.snap` on `cluster-secrets` returns `k8s:enc:aesgcm:v1:key1:` prefix (NOT cleartext YAML)
- [ ] `flux get all --status-selector ready=false` returns empty
- [ ] Fleet rewrite script `failed == 0`
- [ ] `kubectl logs -n loki -l app.kubernetes.io/name=alloy --tail=20 | grep audit` shows entries flowing
- [ ] Grafana → Loki query `{audit_resource="secrets"}` returns events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled API server audit logging (metadata-only for secrets) and forward audit events into centralized logs with extracted labels for easier querying.
  * Host audit log directory mounted read-only into logging agents to collect audit files.

* **Chores**
  * CI workflow refined to lint only cleartext patch files.
  * Added SOPS creation rule to encrypt secret patch files and store API server encryption config securely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->