### PR TITLE
fix(longhorn): swap bitnami/kubectl → rancher/kubectl in instance-manager-rotation

### DIFF
--- a/clusters/main/kubernetes/system/longhorn/app/instance-manager-rotation-cronjob.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/instance-manager-rotation-cronjob.yaml
@@ -57,25 +57,29 @@ spec:
         spec:
           serviceAccountName: instance-manager-rotation
           restartPolicy: OnFailure
-          # Run as a non-root user inside the bitnami/kubectl image (the bitnami
-          # image ships with a non-root user already). This minimizes the
-          # capabilities of a pod that only needs kubectl-list/delete.
+          # rancher/kubectl is an Alpine-based kubectl image that tracks
+          # Kubernetes versions 1:1 with tags like v1.36.1. We use it instead
+          # of the Bitnami image because:
+          #   - bitnami/kubectl (DockerHub) was deprecated Aug 2025 and now
+          #     serves an HTML page instead of a manifest
+          #   - bitnamilegacy/kubectl is frozen at 1.33.4 — no 1.36 tag
+          # Alpine ships a `nobody` user (UID 65534) we can run as.
           securityContext:
             runAsNonRoot: true
-            runAsUser: 1001
+            runAsUser: 65534
             seccompProfile:
               type: RuntimeDefault
           # /tmp is writable via emptyDir so kubectl can write its discovery/http
           # cache under $HOME/.kube/cache when readOnlyRootFilesystem is set.
           # We override HOME -> /tmp so the cache path resolves to /tmp/.kube/cache
-          # regardless of what the bitnami image's default HOME is.
+          # regardless of the image's default HOME.
           volumes:
             - name: tmp
               emptyDir:
                 sizeLimit: 16Mi
           containers:
             - name: rotate
-              image: docker.io/bitnami/kubectl:1.36
+              image: docker.io/rancher/kubectl:v1.36.1
               imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

Fixes the long-stuck `instance-manager-rotation` CronJob in longhorn-system that has been ImagePullBackOff with 1271+ retries.

**Root cause:** Bitnami deprecated their free DockerHub images Aug 2025. `docker.io/bitnami/kubectl:1.36` now serves an HTML deprecation page instead of an image manifest:

```
Failed to pull image "docker.io/bitnami/kubectl:1.36":
unexpected media type text/html for sha256:23f739be... : not found
```

`bitnamilegacy/kubectl` (Bitnami's frozen archive repo) only ships through 1.33.4 — no 1.36 tag.

**Fix:** Switch to `rancher/kubectl:v1.36.1`. Alpine-based, tracks Kubernetes versions 1:1, runs as alpine's `nobody` user (UID 65534).

Both `runAsUser` and image swap in a single diff. No other changes — the CronJob script uses standard kubectl commands that work identically.

## Test plan
- [ ] Flux reconciles `longhorn` kustomization to new SHA
- [ ] Next CronJob trigger spawns a pod that pulls successfully (no more ImagePullBackOff)
- [ ] CronJob script executes (rotates one instance-manager pod per memory note #168)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Longhorn instance manager rotation job configuration, including a container image update and adjusted security context settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->