### PR TITLE
fix(longhorn): rotation script needs /bin/bash for pipefail

### DIFF
--- a/clusters/main/kubernetes/system/longhorn/app/instance-manager-rotation-cronjob.yaml
+++ b/clusters/main/kubernetes/system/longhorn/app/instance-manager-rotation-cronjob.yaml
@@ -96,7 +96,7 @@ spec:
                 - name: tmp
                   mountPath: /tmp
               command:
-                - /bin/sh
+                - /bin/bash
                 - -c
                 - |
                   set -euo pipefail


### PR DESCRIPTION
Followup to #4263. bitnamilegacy/kubectl uses dash as /bin/sh, dash doesn't support pipefail. bash IS in the image at /bin/bash. One-line fix.