### PR TITLE
test(immich): canary pin redis.image to bitnamisecure digest

### DIFF
--- a/clusters/main/kubernetes/apps/media/immich/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/immich/app/helm-release.yaml
@@ -26,6 +26,19 @@ spec:
     remediation:
       retries: 0
   values:
+    # Pin the TrueCharts redis subchart's valkey image to the exact digest
+    # currently cached on the node. The TrueCharts default points at
+    # docker.io/bitnamisecure/valkey:latest, which requires Bitnami Premium
+    # auth (HTTP 401) — image is cached and survives in-place, but next
+    # eviction or restart fails to pull. Pinning by digest gives us a
+    # known-good snapshot and removes the floating-tag risk.
+    # Tracked in tasks #181 (this pin) and #182 (migrate to valkey/valkey).
+    redis:
+      image:
+        repository: docker.io/bitnamisecure/valkey
+        tag: latest@sha256:5ce04fc20634fa151c6050a3aea9fdf30b709509a27af5af1a379b73d18ad58f
+        pullPolicy: IfNotPresent
+
     credentials:
       s3:
         type: s3


### PR DESCRIPTION
Single-app canary to confirm TrueCharts redis subchart accepts the override path. If StatefulSet image changes, follow-up PR pins blocky + paperless-ngx the same way. PR #181 in the bitnami workstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Immich deployment configuration to pin the Redis container image to a specific digest instead of relying on a floating version tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->