### PR TITLE
fix(blocky,paperless-ngx): pin redis.image digest (matches #4265 canary)

### DIFF
--- a/clusters/main/kubernetes/apps/paperless-ngx/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/paperless-ngx/app/helm-release.yaml
@@ -25,6 +25,18 @@ spec:
     remediation:
       retries: 3
   values:
+    # Pin the TrueCharts redis subchart's valkey image to the exact digest
+    # currently cached on the node. TrueCharts default = docker.io/bitnamisecure/valkey:latest,
+    # which requires Bitnami Premium auth (HTTP 401). Image is cached and survives
+    # in-place, but next eviction/restart fails to pull. Pinning by digest
+    # gives us a known-good snapshot and removes the floating-tag risk.
+    # Tracked in tasks #181 (this pin) and #182 (migrate to valkey/valkey).
+    redis:
+      image:
+        repository: docker.io/bitnamisecure/valkey
+        tag: latest@sha256:5ce04fc20634fa151c6050a3aea9fdf30b709509a27af5af1a379b73d18ad58f
+        pullPolicy: IfNotPresent
+
     credentials:
       s3:
         type: s3

--- a/clusters/main/kubernetes/core/blocky/app/helm-release.yaml
+++ b/clusters/main/kubernetes/core/blocky/app/helm-release.yaml
@@ -29,6 +29,18 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    # Pin the TrueCharts redis subchart's valkey image to the exact digest
+    # currently cached on the node. TrueCharts default = docker.io/bitnamisecure/valkey:latest,
+    # which requires Bitnami Premium auth (HTTP 401). Image is cached and survives
+    # in-place, but next eviction/restart fails to pull. Pinning by digest
+    # gives us a known-good snapshot and removes the floating-tag risk.
+    # Tracked in tasks #181 (this pin) and #182 (migrate to valkey/valkey).
+    redis:
+      image:
+        repository: docker.io/bitnamisecure/valkey
+        tag: latest@sha256:5ce04fc20634fa151c6050a3aea9fdf30b709509a27af5af1a379b73d18ad58f
+        pullPolicy: IfNotPresent
+
     global:
       stopAll: false
     service:


### PR DESCRIPTION
Applies the same redis.image override pattern as #4265 (immich canary) to the remaining two valkey consumers — blocky/blocky-redis-0 and tools/paperless-ngx-redis-0. Closes the mitigation layer of task #181. Migration to valkey/valkey upstream image follows in task #182.