### PR TITLE
feat(secrets): move encryption-config + audit host paths to /var/etc/

### DIFF
--- a/clusters/main/kubernetes/system/alloy/app/helm-release.yaml
+++ b/clusters/main/kubernetes/system/alloy/app/helm-release.yaml
@@ -138,7 +138,14 @@ spec:
         extra:
           - name: kube-audit
             hostPath:
-              path: /var/log/audit
+              # Talos writes audit logs here (audit-policy.yaml patch sets
+              # the apiserver --audit-log-path to /var/log/audit/audit.log
+              # INSIDE the apiserver pod, which is bind-mounted from this
+              # host path). The original /var/log/audit path worked, but
+              # /var/log/k8s-audit avoids any collision with system auditd
+              # (Talos's auditd service writes to /var/log/audit/* on the
+              # host too).
+              path: /var/log/k8s-audit
               type: DirectoryOrCreate
 
     serviceMonitor:

--- a/clusters/main/talos/patches/audit-policy.yaml
+++ b/clusters/main/talos/patches/audit-policy.yaml
@@ -4,27 +4,40 @@
 # RequestResponse would write cleartext credentials into the log and
 # require Loki access hardening per the PR 5 plan (Task 5.6 Step 3).
 #
+# Host paths use /var/etc/ and /var/log/k8s-audit/ instead of
+# /etc/kubernetes/ — the original /etc/kubernetes/ paths wedged the
+# kubelet bootstrap on 2026-06-09 because Talos mounts /etc/kubernetes/
+# read-only during early boot before the machine.files controller runs.
+# See docs/runbooks/encryption-audit-staged-patch.md and task #185.
+#
 # Audit log file is mounted into Alloy DaemonSet via hostPath; see
 # clusters/main/kubernetes/system/alloy/app/helm-release.yaml.
 
 cluster:
   apiServer:
     extraArgs:
+      # In-pod paths — apiserver still sees /etc/kubernetes/ inside its container
       audit-policy-file: /etc/kubernetes/audit-policy.yaml
       audit-log-path: /var/log/audit/audit.log
       audit-log-maxsize: "100"
       audit-log-maxbackup: "5"
     extraVolumes:
-      - hostPath: /etc/kubernetes/audit-policy.yaml
+      # Bind /var/etc/kubernetes/audit-policy.yaml (host) → /etc/kubernetes/audit-policy.yaml (pod)
+      - hostPath: /var/etc/kubernetes/audit-policy.yaml
         mountPath: /etc/kubernetes/audit-policy.yaml
         readonly: true
-      - hostPath: /var/log/audit
+      # Bind /var/log/k8s-audit/ (host, writable) → /var/log/audit/ (pod)
+      # Alloy DaemonSet reads /var/log/k8s-audit/ on the host directly.
+      - hostPath: /var/log/k8s-audit
         mountPath: /var/log/audit
         readonly: false
 
 machine:
   files:
-    - path: /etc/kubernetes/audit-policy.yaml
+    # Write the audit policy to /var/etc/kubernetes/ on the host.
+    # The extraVolumes block above mounts it at /etc/kubernetes/ inside
+    # the apiserver pod so the audit-policy-file flag finds it.
+    - path: /var/etc/kubernetes/audit-policy.yaml
       permissions: 0o600
       op: create
       content: |

--- a/clusters/main/talos/patches/encryption-config.secret.yaml
+++ b/clusters/main/talos/patches/encryption-config.secret.yaml
@@ -1,39 +1,39 @@
-#ENC[AES256_GCM,data:DJmUa1jqEuy+gkPbwKIt/8QnluWpFjsLQcHhDC3ccqbRaZ8dPsKBp22+8IRyPn2C7WbBAakaOQk02wrbBCn/mbZ7wQ==,iv:wInRshEYiw9Ug86j8cTfkXNCAhE8SXA2pqRXO0ZMyBs=,tag:d0VWfyqoRZrjGZaX8zMDzg==,type:comment]
-#ENC[AES256_GCM,data:F/jwXReduf/LtEtqiFRp2b8vUNWIRus7I8on5n3Isb+Jy0ueQU0MKuPGq85kOUDAk6yAf/cCLMhBvKrZeVRRkqdTDMc1,iv:OBWev5hLFZVf0zUEl1a1KS2HlpTxwHKakTTzw5xDKD8=,tag:ovi6i7MpqZHx2s1PMCHf9w==,type:comment]
-#ENC[AES256_GCM,data:FmXIjU4w3rwUFZKtUlkGOO4yjujexnOMf1X7q02SNaFs1cOgePCUn9Js+TYS02YYWtI29qZpxMcB5xDViGXL7w==,iv:xchJLyvIRjQHIdjx7U96dUsVV1oLoxo5E/ZKXmJjf+s=,tag:Q7L1F+0LJgP68iX7X0W1tA==,type:comment]
+#ENC[AES256_GCM,data:gVQ2VB29jAOVYJZGR0j+PV5jAljPTX3TUPZDmCqwa7np+trQsaWABPXlDdALs07he9wt6wlCJkz8nd1/qaXdK7p73A==,iv:D3gg+EsmpvO2ka7QQxcyqFZTq6d5KPiVoML7dwRai50=,tag:woQAJo4d3A+/6/nuvsPzFg==,type:comment]
+#ENC[AES256_GCM,data:3MQU9+mlxxrohCsLIey3Jp6xsneGSSDLM2tTJprEhtO6e//+ezWxomrEsqwJtRgqQoRpFQo9bIPlcNX0vga7x/EwLCAP,iv:K8rzuNwE32JSR3CtTjRIu+DJZSyT1v3JYlqmm6ypIfo=,tag:zvYDdEpsOLFZZUHAlnEtbg==,type:comment]
+#ENC[AES256_GCM,data:2MhPxx+qm3SZvyfWZPA11m48tWkJ9HlUclAUVFfWxGCQzpFV7NrSEW7z7WtAvESdgncNlHVIX+8ShSTArNwjXQ==,iv:o3oAuOM7ObR9ruPY+jmjhPs7AAHT7n7arzj0VD9PIWY=,tag:rHmFQOZTgvVHOzexO+dl6A==,type:comment]
 #
-#ENC[AES256_GCM,data:UF3RQSfs7Iz352vkWvmaMZAavW82OoYXHRWjmGkdsRLIYy0fDlfKprIMRrAfAiJDLCSRrozwoReoAkKjeA==,iv:mL8eEylb2Vj83HEIqu933agJ7iXMbkHOkPp5CUAC4cI=,tag:ovnlSCPZyIi8H6cHYQ1HlQ==,type:comment]
-#ENC[AES256_GCM,data:Zf+WredsadwXHuHtzbb0lqf4Udw42rbE8qPqka4HSqzuYorCISKRgmdG8xbwvnfoNihr0dIbC4kuHI9LvyzdYM1HdSA=,iv:U1KDBFzs8UhbIe5hcVZxZ4u3jMN2qh4/3na0sXSxZnM=,tag:j86ciAYRbqiKYL+2o0p4KQ==,type:comment]
-#ENC[AES256_GCM,data:vfGlsQaP5EuXF8GUGT47CJIE770hL5JyysbPg7SRLkmjotKX3wt+/b7IkWf4HEuAOUxXLN6Ag2u1ghgJZ9PUt+hZ5oAIPgg=,iv:Sz5vD4OhGJr0UR6G7wZPQgMq67gylx1MLaeGZrQFjcY=,tag:kNJtFmOhSW90UTtTrVG4cQ==,type:comment]
-#ENC[AES256_GCM,data:j6Vo/pZVptxUzM8+2VBgiyoRyxjVc9UYS2/X455HYhvSaO3rYPw11KUzwrC/0i9oSRhzIwDHeorVCzhQHImL4J1ZI+sZaA==,iv:uJaftAtOtvdhss8NKxQBKUXkeMxeXENeOMuzqCU5jn0=,tag:CKHiWWwOksxV5inr2z7j4Q==,type:comment]
-#ENC[AES256_GCM,data:tGnzq3bRGKoUWyp7QitKPI/NOCK21YlINMwaMIeuG6mznnmxHfC3LxkPvEz5yTocDH36L5sIjdtFpNUhc7pWfs/1GZCEjfA=,iv:WmhWrRgr1RaaooXCzbtwVO2c7bGRsn051sEgeicodJ4=,tag:QbWzDwi9qIgFLInfzSQJcQ==,type:comment]
-#ENC[AES256_GCM,data:23HDUavkuhM0Zk2z2p1YELV/wtZL7zvH08CH81SOxrVMSmu9pz62rYTV7Sku0B+91jv9SQoQhk60TeJ3e++2uQyfuH6RVlwB9A==,iv:0nyKtnSWvDcOo651vjcHB7FFT4fSfgwi/vXwjoh6+9Y=,tag:Nln2dxOeYYs/ncHxg/0JCw==,type:comment]
+#ENC[AES256_GCM,data:Oly+fi0HG7ErVZgxbQl9+tjkPWFqS4o6N6MtWCLqqTkmkUbVCzax8twdow3ZRpZTz7F8YLEi1hiwsD+06Q==,iv:fQxFQzGO+UK5am9vjQJHESY+9FocX1UBbQU1q6mB2zE=,tag:tRNjOIqIFK+1ot8pSF0vXA==,type:comment]
+#ENC[AES256_GCM,data:8Vasg4rp09vxdOLvnmtmM6vFHqWU3GEUwHbmMrDbZi2cSKrT085WkA+17SgrzbbMc/Th0jOPq84oiCrYsBdkQV+ZtPE=,iv:lKkMlN0btwxh20PQ44fFaWULcWGe+jpCgDpKwb+415Q=,tag:zs4LDQXIrR4Me4exKTOOsw==,type:comment]
+#ENC[AES256_GCM,data:ZsVrgazZYoVAH4bNx29QKcVtX5ezfjZLw2IXEPWHp437jFzEPB7rLUEujXqlBN/P8UDtyt2QAeSduFxRVnDbvLv8N0dEjVs=,iv:Rm2ZAHs8TYV524GaWAaYKt+upS6AcHTW0igbik6z6zU=,tag:9FBQMNyrlNG46h6e32kB/A==,type:comment]
+#ENC[AES256_GCM,data:yFjhiIO94YsOzQfXFcrWFJdLzH8bnod0WhoB+8zno2JaEOxhsyvGQA/F1gu0hcDp7I7h94x3c20RdDlASciMrCLdrwY4TA==,iv:fDbXqBkJ4qCn/gJR2abSnH51lkWNIen9sIrVMiwgPBw=,tag:HTp3pakHPEWvhape1Yb0Yg==,type:comment]
+#ENC[AES256_GCM,data:1UPdFUyOaOs0Akntfqvgv8qYalVStdKklQbrAKcLxp0Y5tOn31AS5sf4ty5GVSIpmexF2v29nT7AgPnkCqC3tm/DwA2wXg0=,iv:6xE6ScXTOv3tgbRqPSpZ8J9+tij1o+D8C2WYj1q4GGs=,tag:ZiPN42QycPxMBX6mXL78rg==,type:comment]
+#ENC[AES256_GCM,data:FUjWoKVnIcFFp4FNntY2MQLekBp1S6xMU7UxDVIBnXCiMBdqcsNbXRhyEBLdbvwNIGLacrHZb/jPPWnplWnP9YLVU3HiWXlKbg==,iv:zPaPligwpQGRs+2Nm8YeYJWoZzfFjflS3kMTAymQXt8=,tag:9oGjH1KfnMp5rjf2rZHigg==,type:comment]
 cluster:
     apiServer:
         extraArgs:
-            encryption-provider-config: ENC[AES256_GCM,data:PoGxVvjS8P3E+pZfE5Vo8JuZawET9Tyq11fFL3pjcvoc2lf0aec=,iv:stWbj8vfzeGDUNc8uH7I7gC42wPsY/v9C9c34B9ttVU=,tag:uaXbYzHoSGdXUB8TPJr6MQ==,type:str]
+            encryption-provider-config: ENC[AES256_GCM,data:gvKquXK2azc0NMtFhd2H94SFZtQoC7j/K0no2W5lrJ/I1/x+XbE=,iv:n9h1DstZ6kjDRc7q3L1aE2TrnYQOI11z4vB0n2CkNj0=,tag:aQVSw7IE85DHrBMApvhoqg==,type:str]
         extraVolumes:
-            - hostPath: ENC[AES256_GCM,data:JHl3L7WNfveIg6MpeHQihvWvxpvtj5qW7wCrX44x8IcaiPn/sxY=,iv:ai9P+DWsZRz211jV+zzYoyoxdB1pbTvUtv2zvvPB/gk=,tag:i8h4PzhVhLJKq3eCvnSSCw==,type:str]
-              mountPath: ENC[AES256_GCM,data:1TF02SW3dYeM13stuvfvwjsi7FR0vL227Wvsgc4ZSDJoXg52rHk=,iv:YPsPr5I6gs0Jz0RKUzcZIqglqslIsMl8hiQgrgQWdPQ=,tag:Ng0hMxkgdtgA/fHKsokeLg==,type:str]
-              readonly: ENC[AES256_GCM,data:XHgp+Q==,iv:IV6evEViEQTlneUv9L3MdPtWp2BS2pZlMLSuqdj2HrE=,tag:rQ6AoyBhhHrs8knZp50vOQ==,type:bool]
+            - hostPath: ENC[AES256_GCM,data:65G2fGGhyCY2eaX0MPpqF26+pEEb2X+62AYMkadnPnWOUq0iZ1QYkopR,iv:/3utrvI0vXHmH+TUhWbI8f1zY/JXiKmGfj+4qPcI7Rk=,tag:e+CYbWczSjkXF79Rms0r5Q==,type:str]
+              mountPath: ENC[AES256_GCM,data:tytqIpYnN1GDjG/ubnq58NRImZ4C/XIv6sfMXBwLxDX6FlMt+S8=,iv:BWYJ9Z5hxndUTSNNjVjDbFVxSTTNLTFxfNSAQTTku9M=,tag:QW8ncJMFOHlA/Pg86kFIqg==,type:str]
+              readonly: ENC[AES256_GCM,data:tPMm/g==,iv:6vMZlf/R/CeBqMUHlXKIxAlg/MdFkXTIpyit7+yirT0=,tag:NtZlf6zYimnEOYrL8YcBbA==,type:bool]
 machine:
     files:
-        - path: ENC[AES256_GCM,data:vm1UhFiU0yU80QAFESeTekF55cfG8JST3wLmaWC7mSojQ8yTZNk=,iv:yH3MY3+a3lgx7FE7vrWKOBL6FjLMHc0Bg0ysj/av4mw=,tag:5kWXT4bEJE+wOzysGyQohA==,type:str]
-          permissions: ENC[AES256_GCM,data:Lemv,iv:4j6+nz7wB/WfaxvEuneeCiyLagPxgVUEjh5ntb0MBCs=,tag:MQw2f3VJ8IdiwL6PBYYHCQ==,type:int]
-          op: ENC[AES256_GCM,data:qPW+FS+b,iv:DoFjRartZecTJrpABqIe7dHstyZekapcTjGJpDEdqXQ=,tag:gu8MwegASf3IxjT+Y1lRQg==,type:str]
-          content: ENC[AES256_GCM,data:khS8QY2bUuQyXQrlzJlDuVY/GQbKMcWEdsprPtptx3PLszXBjlomZDiNNSqpG8Ub3sadVKHv+1dS1lmv8JxtIjL0xnm2rGPu4K/wV9Vc4YhX5X568P09fxA4/VJUlBznTh2F3v8invwlZQPhfAG5ZpiXRmA0XgOeZCIh4YAVhDxRwxQSEHn/8XOv3lMkt2oi9J16io6hbdvAg7kyaUPg6kEkHaznw0KPCIYjzYsNk0xOXeu5YpKIwyVSFDR0JSXPitvfD6EMHkPgU56E9qfADyHxj+4R4EVPY9cv8Etpg81Cfu7fwkaBXxxWfJZ0K+EPwgkgIpKLddZADVdz9sWm2FxaS4bF8JWY9mOLSjaClQ==,iv:4aaTdq8XSVOJ8OByv7PsVXuw4Yvzy7TLg+fOItnQNj8=,tag:aZh+1GCj1gcahC9wqLpWVA==,type:str]
+        - path: ENC[AES256_GCM,data:1IxPMd3JnOsrCqsN5CX0M8QnVSz5WLkYwqeqN1geCNM73BUgAE0pZfR9,iv:YR02mJCJIBbVXnEgcLU67x6Jbl48SFKELjajNEhOYYc=,tag:LOWCK4qPeLK4DgfUDmqkLQ==,type:str]
+          permissions: ENC[AES256_GCM,data:oHz4,iv:J/oKy2ZJNl7LvpCoKRAg6cNDMq93quIeC/9SriyH+BA=,tag:q0gfllluGyiTETG9G3Worg==,type:int]
+          op: ENC[AES256_GCM,data:H47yF9/j,iv:2kIApvN3O3N7xKZ0sA+j5BoDn1O5T5JMfjXED4MM660=,tag:QHRH4PBAO7m6ccAv27w/7A==,type:str]
+          content: ENC[AES256_GCM,data:Ke74jAmX6ddl7X8wUqj9MFpfyAJaQEdwingCI9w+hwnAzC28xoS+LpJ5gay4akqYxay3oSw21pGkh81vuqWaihKzmgCiq4IFI0hzfyKUlqA2n/3Pu90cZ16sflhSHcWf8xE9KaNc0JBdQ9fckKVBUd0CwPj45CEwJZ/JJXJVUD4DMWGmc83eHF8ifCCs+WspMKPmOvGP2PtNy6oj6EITJtBrUj7uHj8oAl0wSsZyjB6bkZupExBh4UbyqE/Ig17bD48+ovUCVdfaWKqMfEKrlFui2K1SSxztV12JFJ8owZEXBFgDQgiIYCQT913U7NmHTVfrMJWOciZwpBveWrQ0EqQck0NILOjC2qxjaJBkWw==,iv:Cv4T2RdA4E8mpVzg7SUPZMlCyKLUj6GcFZCoiAvF6pE=,tag:lDtQDGqUFnCfB7LBbDyw4A==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBycTRkV0xNNmlPRWF1dW5I
-            OUtHVkUxMTl3amJqRVk5dW1vZnlXVVhKaW04CndYVERRMy9TNnAyK05MbUlpdWRJ
-            SUg0dExaNkNUS3l6cWY3V00zUTRLaEkKLS0tIHZGUTdtS3JBTTN6Rm1OMnRZR1Qv
-            eEpjUE5NSzdQdG5jbmNkZ2wxUGFQVjAKpuO3DNDzKyB99/VZe5Ifz0W2d8e2f12p
-            0vrHW6yM4nYjGrbfFKjUnE0gE8OX80mNmVlV6Ds7VFiGRE/fBHrJqQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEdVN0VzJHRmZ5aE1jR3dQ
+            R2VEOThBTmhzSFVzWWNMak9WWW50MWRYUW1NCnJkNnp5aW9HTTJrODZqRnFadTVC
+            aC9qcXpiZVdsbUI0WkpKYkJPM3FtUjAKLS0tIG4vQng4MFlkRUd0V0xrcGFUVUww
+            MkhaWG1kWFlTUnRGdTFlM2huNVZxVVEKV7mesmt/UKUK9USFty0ndmfRqHM2uLQc
+            oCB2/ndE5gGclzdxMmuGCO7M/BtPu9XIAtSSz2zu3smdX4Lx80Gj2Q==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xuryc2afg7fh6tg2d85mydr05rh93xf8dhrcq4xata7ec33t8uvs6kl3yw
-    lastmodified: "2026-06-09T22:16:03Z"
-    mac: ENC[AES256_GCM,data:73qS9IdcnUuf+ag01/nGhwQd5roiWhXAHRwjRYIef712mTdZWFZq6J61ZW2MN41LGyaHu6gd9rIxI+Aq9fJEjUAbJL7deLAFoJNsnA85eJ82cZxRbnbgIqPtU8r8DocYi3qkkhGlcLkDhf2Grj19gzaJn41lzZH8YvZgrff2Upc=,iv:ggzrFFiawchhIHuTJbGbZT4LJsEwRDZWUhpJpXXqa0Q=,tag:+4QtznwezGygwi42Vx90Ew==,type:str]
+    lastmodified: "2026-06-10T00:20:07Z"
+    mac: ENC[AES256_GCM,data:EotYfsJcC2SGGhYrKPMF8BpAbhiNpILANSXFZCASs+MrI8lYR7Af4jLR3hGsA0NlvvH+UuagnngmlJ1QsG+Q573chgW/TNu6lm72b/2sazRGJDngEoQ7Hxk+vujq9Bkwnsc1LAQeUsU0DLELsrQdyXJFbhZBQSirPQcGfM/JobA=,iv:I1B5m1iH6XOAb6tnXmxX+H7MD52bdCXKEGh+sfkiJ4c=,tag:h+lgHgST8GzLPk4X8x+5Tw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1

--- a/docs/runbooks/encryption-audit-staged-patch.md
+++ b/docs/runbooks/encryption-audit-staged-patch.md
@@ -1,119 +1,127 @@
 # Etcd encryption + Audit policy — staged Talos patch
 
-Staged on the live control-plane node via `talosctl patch mc --mode=staged`
-on 2026-06-09. Takes effect at the next reboot of `k8s-control-1`
-(192.168.10.89).
+**Status:** repo files updated 2026-06-09 to use `/var/etc/kubernetes/` host paths after the original `/etc/kubernetes/` paths boot-wedged the cluster. Patch has NOT yet been applied/staged to the live node — that's a separate operation pending a quiet maintenance window.
 
-The same configuration exists in the SOPS-encrypted Talos patch
-`clusters/main/talos/patches/encryption-config.secret.yaml` and
-`clusters/main/talos/patches/audit-policy.yaml`, but a full
-`talos apply` of the generated machine config would:
+## Background — what changed
 
-- reboot the node anyway (new `machine.files` aren't hot-reloadable)
-- re-introduce the `scheduler.config` block that wedged the cluster
-  on May 26 (memory note: it was removed via JSON patch as the live
-  workaround)
-- bump `install.image` v1.11.1 → v1.13.4
+The 2026-06-09 first attempt used host paths under `/etc/kubernetes/` (matching what the K8s docs typically show as the apiserver-side encryption-config location). That triggered a boot wedge:
 
-So the surgical strategic-merge patch below was applied directly
-to the live node instead. The repo files remain authoritative for
-what the EncryptionConfiguration *should* be — this is the runbook
-for re-staging or re-applying it on a fresh node.
-
-## Patch contents
-
-```yaml
-machine:
-  files:
-    - path: /etc/kubernetes/encryption-config.yaml
-      permissions: 0o600
-      op: create
-      content: |
-        apiVersion: apiserver.config.k8s.io/v1
-        kind: EncryptionConfiguration
-        resources:
-          - resources:
-              - secrets
-            providers:
-              - aesgcm:
-                  keys:
-                    - name: key1
-                      secret: <THE-KEY-FROM-encryption-config.secret.yaml>
-              - identity: {}
-    - path: /etc/kubernetes/audit-policy.yaml
-      permissions: 0o600
-      op: create
-      content: |
-        apiVersion: audit.k8s.io/v1
-        kind: Policy
-        omitStages:
-          - RequestReceived
-        rules:
-          - level: Metadata
-            resources:
-              - group: ""
-                resources: ["secrets"]
-          - level: None
-cluster:
-  apiServer:
-    extraArgs:
-      encryption-provider-config: /etc/kubernetes/encryption-config.yaml
-      audit-policy-file: /etc/kubernetes/audit-policy.yaml
-      audit-log-path: /var/log/audit/audit.log
-      audit-log-maxsize: "100"
-      audit-log-maxbackup: "5"
-    extraVolumes:
-      - hostPath: /etc/kubernetes/encryption-config.yaml
-        mountPath: /etc/kubernetes/encryption-config.yaml
-        readonly: true
-      - hostPath: /etc/kubernetes/audit-policy.yaml
-        mountPath: /etc/kubernetes/audit-policy.yaml
-        readonly: true
-      - hostPath: /var/log/audit
-        mountPath: /var/log/audit
-        readonly: false
+```
+error writing kubelet PKI: open /etc/kubernetes/bootstrap-kubeconfig: read-only file system
 ```
 
-## To re-stage
+Talos mounts `/etc/kubernetes/` read-only during early boot (before the `machine.files` controller runs) so the kubelet `KubeletServiceController` controller can lay down its bootstrap kubeconfig safely. Declaring our own `machine.files` entries under `/etc/kubernetes/` confused the mount ordering — the directory came up RO before kubelet bootstrap could write to it.
+
+**The fix in this PR:** move host-side paths to `/var/etc/kubernetes/` (same area Talos already uses for `nfsmount.conf`). Keep the in-pod `mountPath` at `/etc/kubernetes/` so the apiserver still finds its files where it expects them.
+
+## Host vs in-pod path mapping
+
+| Component | Host path | In-pod path (apiserver) |
+|---|---|---|
+| EncryptionConfiguration | `/var/etc/kubernetes/encryption-config.yaml` | `/etc/kubernetes/encryption-config.yaml` |
+| Audit policy | `/var/etc/kubernetes/audit-policy.yaml` | `/etc/kubernetes/audit-policy.yaml` |
+| Audit log output | `/var/log/k8s-audit/audit.log` | `/var/log/audit/audit.log` |
+
+Alloy DaemonSet mounts host `/var/log/k8s-audit/` → in-pod `/var/log/audit/` so its `loki.source.file "audit"` config can keep targeting `/var/log/audit/audit.log` unchanged.
+
+## Repo files (authoritative)
+
+- `clusters/main/talos/patches/encryption-config.secret.yaml` (SOPS-encrypted)
+- `clusters/main/talos/patches/audit-policy.yaml`
+- `clusters/main/kubernetes/system/alloy/app/helm-release.yaml`
+- `.sops.yaml` (rule for talos patches/*.secret.yaml)
+
+## Apply procedure (DEFERRED — requires hands-on maintenance window)
+
+The apply path is the same as the prior attempt, just with the new host paths:
 
 ```bash
-# Get the key from the SOPS-encrypted patch
-SOPS_AGE_KEY_FILE=$PWD/age.agekey \
-  sops --decrypt clusters/main/talos/patches/encryption-config.secret.yaml \
-  | grep "secret:" | awk '{print $2}'
+# 1. Generate Talos config (needs HEADLAMP_IP set in clusterenv per b9741b40b)
+./clustertool-new genconfig
 
-# Write the patch with the key inlined, then:
-talosctl --talosconfig clusters/main/talos/generated/talosconfig --nodes 192.168.10.89 \
-  patch mc -p @/tmp/encryption-audit-patch.yaml --mode=staged
+# 2. Restore any decrypt-in-place artifacts (feedback_genconfig_decrypts_in_place)
+git status --short  # check for unintended .secret.yaml diffs
+for f in $(git status --short | awk '{print $2}'); do
+  case "$f" in
+    *.secret.yaml|clusters/main/clusterenv.yaml|clusters/main/talos/generated/talsecret.yaml)
+      git restore "$f" ;;
+  esac
+done
+
+# 3. CRITICAL: dry-run BEFORE staging. Must report "no reboot required" — if it
+# still says "Applied configuration with a reboot", DO NOT proceed. Investigate
+# whether the new host paths trigger different filesystem semantics.
+talosctl --talosconfig clusters/main/talos/generated/talosconfig \
+  --endpoints 192.168.10.89 --nodes 192.168.10.89 \
+  apply-config --file clusters/main/talos/generated/main-k8s-control-1.yaml --dry-run
+
+# 4a. If dry-run is clean, stage for next maintenance reboot:
+talosctl --talosconfig clusters/main/talos/generated/talosconfig \
+  --endpoints 192.168.10.89 --nodes 192.168.10.89 \
+  patch mc -p @clusters/main/talos/generated/main-k8s-control-1.yaml --mode=staged
+
+# 4b. Then reboot during a planned window:
+talosctl --talosconfig clusters/main/talos/generated/talosconfig \
+  --endpoints 192.168.10.89 --nodes 192.168.10.89 etcd snapshot /tmp/etcd-pre-reboot-$(date -u +%Y%m%dT%H%M%S).snap
+talosctl --talosconfig clusters/main/talos/generated/talosconfig \
+  --endpoints 192.168.10.89 --nodes 192.168.10.89 reboot
 ```
 
-## To check whether it's active (after reboot)
+## Post-reboot verification
 
 ```bash
-# 1. apiserver flags
-kubectl get pod -n kube-system kube-apiserver-k8s-control-1 -o yaml \
-  | grep -E "encryption-provider-config|audit-policy-file"
+# 1. apiserver back?
+until kubectl get --raw=/livez >/dev/null 2>&1; do sleep 5; done
 
-# 2. force cluster-secrets through the new provider
+# 2. encryption-config file present on host AND in apiserver pod?
+talosctl --talosconfig clusters/main/talos/generated/talosconfig \
+  --endpoints 192.168.10.89 --nodes 192.168.10.89 \
+  read /var/etc/kubernetes/encryption-config.yaml | head -5
+kubectl exec -n kube-system kube-apiserver-k8s-control-1 -- ls -la /etc/kubernetes/encryption-config.yaml
+
+# 3. Force-replace cluster-secrets so it's encrypted via the new provider
 kubectl get secret -n flux-system cluster-secrets -o yaml | kubectl replace -f -
 
-# 3. verify etcd ciphertext
-talosctl --talosconfig clusters/main/talos/generated/talosconfig --nodes 192.168.10.89 \
-  etcd snapshot /tmp/etcd.snap
-go install go.etcd.io/bbolt/cmd/bbolt@latest
+# 4. Verify etcd-side encryption (bbolt)
+talosctl --talosconfig clusters/main/talos/generated/talosconfig \
+  --endpoints 192.168.10.89 --nodes 192.168.10.89 etcd snapshot /tmp/etcd.snap
+go install go.etcd.io/bbolt/cmd/bbolt@latest  # if not installed
 bbolt get /tmp/etcd.snap key /registry/secrets/flux-system/cluster-secrets | head -c 200
 # Expect prefix: k8s:enc:aesgcm:v1:key1:
-```
 
-## Post-reboot fleet rewrite
+# 5. Audit log flowing into Loki via Alloy
+kubectl logs -n loki -l app.kubernetes.io/name=alloy --tail=20 | grep audit
+# In Grafana: {audit_resource="secrets"}
 
-After reboot + cluster-secrets verified encrypted, run the fleet rewrite
-from plan Task 5.4 to bring all other Secrets through the new provider:
-
-```bash
+# 6. Fleet-wide Secret rewrite (resolves Decision A2). Script from plan Task 5.4.
 /tmp/fleet-rewrite-secrets.sh dry-run | tee /tmp/rewrite-dryrun.log
 /tmp/fleet-rewrite-secrets.sh apply   | tee /tmp/rewrite-apply.log
 ```
 
-Script body is in `.claude/plans/2026-06-09-flux-secrets-migration.md`
-Task 5.4 (lines 1282–1421).
+## Rollback (symmetric)
+
+If something goes wrong, the recovery from 2026-06-09 demonstrated the working pattern:
+
+```bash
+# Remove the apiserver bits via JSON patch (apid is reachable even when apiserver isn't)
+cat > /tmp/revert-patch.json <<'EOF'
+[
+  {"op": "remove", "path": "/cluster/apiServer/extraArgs/encryption-provider-config"},
+  {"op": "remove", "path": "/cluster/apiServer/extraArgs/audit-policy-file"},
+  {"op": "remove", "path": "/cluster/apiServer/extraArgs/audit-log-path"},
+  {"op": "remove", "path": "/cluster/apiServer/extraArgs/audit-log-maxsize"},
+  {"op": "remove", "path": "/cluster/apiServer/extraArgs/audit-log-maxbackup"},
+  {"op": "remove", "path": "/cluster/apiServer/extraVolumes/2"},
+  {"op": "remove", "path": "/cluster/apiServer/extraVolumes/1"},
+  {"op": "remove", "path": "/cluster/apiServer/extraVolumes/0"},
+  {"op": "remove", "path": "/machine/files/3"},
+  {"op": "remove", "path": "/machine/files/2"}
+]
+EOF
+talosctl --talosconfig clusters/main/talos/generated/talosconfig \
+  --endpoints 192.168.10.89 --nodes 192.168.10.89 \
+  patch mc -p @/tmp/revert-patch.json --mode=auto
+# Talos will reboot once into a clean config.
+```
+
+NOTE: the array indices in `/machine/files/N` and `/cluster/apiServer/extraVolumes/N` depend on the current config state. Use `talosctl get machineconfigs -o yaml` to confirm indices before running the revert.


### PR DESCRIPTION
## Summary

Follow-up to #4261. Re-architects the etcd-encryption + audit-policy Talos patches so they DON'T boot-wedge the cluster.

### What went wrong on 2026-06-09

PR #4261's original host paths were under \`/etc/kubernetes/\`. Talos mounts that directory read-only during early boot before the \`machine.files\` controller runs, so kubelet's \`KubeletServiceController\` can write its bootstrap kubeconfig. Adding our own \`machine.files\` entries there confused the mount ordering — directory came up RO before kubelet bootstrap could write, and the cluster wedged with:

\`\`\`
error writing kubelet PKI:
open /etc/kubernetes/bootstrap-kubeconfig: read-only file system
\`\`\`

Recovery: JSON-patch revert via apid while apiserver was wedged. apid stayed responsive (~3 min into the wedge cycle), let us \`talosctl patch mc\` away the offending entries. Boot cleanup in 22s.

### Fix

Move host-side paths to \`/var/etc/kubernetes/\` (same area Talos already uses for \`nfsmount.conf\` — confirmed working). Keep in-pod \`mountPath\` at \`/etc/kubernetes/\` so the apiserver finds files where it expects them.

| Component | Host path | In-pod path (apiserver) |
|---|---|---|
| EncryptionConfiguration | \`/var/etc/kubernetes/encryption-config.yaml\` | \`/etc/kubernetes/encryption-config.yaml\` |
| Audit policy | \`/var/etc/kubernetes/audit-policy.yaml\` | \`/etc/kubernetes/audit-policy.yaml\` |
| Audit log output | \`/var/log/k8s-audit/audit.log\` | \`/var/log/audit/audit.log\` |

Alloy DaemonSet hostPath updated to match. Its \`loki.source.file\` config keeps targeting the in-pod \`/var/log/audit/audit.log\` — the host-to-pod mapping does the translation.

### Critical pre-apply gate (in runbook)

\`\`\`bash
talosctl apply-config --dry-run
\`\`\`

**Must report "no reboot required"**. If it still says "Applied configuration with a reboot", DO NOT proceed — investigate whether the new paths trigger different filesystem semantics. This is the gate that would have caught the 2026-06-09 incident.

## NOT YET STAGED/APPLIED

This PR is files-only. The cluster apply is a separate operation pending a quiet maintenance window. Procedure documented in \`docs/runbooks/encryption-audit-staged-patch.md\`.

## Test plan
- [ ] CI Talos schema validation passes
- [ ] sops checkcrypt passes
- [ ] Future apply: dry-run reports "no reboot required" OR fails CLEANLY without wedging
- [ ] Post-apply: \`kubectl exec -n kube-system kube-apiserver-k8s-control-1 -- ls /etc/kubernetes/encryption-config.yaml\` finds it
- [ ] Post-apply: \`bbolt get /tmp/etcd.snap key /registry/secrets/flux-system/cluster-secrets\` shows \`k8s:enc:aesgcm:v1:key1:\` prefix
- [ ] Post-apply: Grafana Loki query \`{audit_resource="secrets"}\` returns events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Kubernetes apiserver boot issue by relocating audit and encryption configuration files to prevent read-only mount conflicts.

* **Documentation**
  * Updated operational runbook with new file paths and streamlined deployment and verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->