### PR TITLE
fix(netpol): allow CNPG operator → instance pods on :8000/pg/status

### DIFF
--- a/clusters/main/kubernetes/apps/network-policies/app/media-netpol.yaml
+++ b/clusters/main/kubernetes/apps/network-policies/app/media-netpol.yaml
@@ -57,3 +57,11 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: triparr-bot
+    # CNPG operator → instance pod :8000/pg/status (used by operator to
+    # scrape PostgreSQL instance status). Without this, the operator
+    # reports "Instance Status Extraction Error: HTTP communication issue"
+    # and helm releases that wait on Cluster.status time out.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudnative-pg

--- a/clusters/main/kubernetes/apps/network-policies/app/ollama-netpol.yaml
+++ b/clusters/main/kubernetes/apps/network-policies/app/ollama-netpol.yaml
@@ -57,3 +57,10 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: networking
+    # CNPG operator → instance pod :8000/pg/status (used by operator to
+    # scrape PostgreSQL instance status for openwebui-db cluster). Without
+    # this the operator reports "Instance Status Extraction Error".
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudnative-pg

--- a/clusters/main/kubernetes/apps/network-policies/app/triparr-bot-netpol.yaml
+++ b/clusters/main/kubernetes/apps/network-policies/app/triparr-bot-netpol.yaml
@@ -36,3 +36,10 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: monitoring
+    # CNPG operator → instance pod :8000/pg/status (used by operator to
+    # scrape PostgreSQL instance status). Without this, the operator
+    # reports "Instance Status Extraction Error: HTTP communication issue".
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudnative-pg


### PR DESCRIPTION
CNPG operator was being blocked by the March 2026 ingress-only netpols on media, triparr-bot, and ollama namespaces. Cluster.status couldn't be populated → helm releases timed out waiting on it. Adds cloudnative-pg namespace as an allowed ingress source.