### PR TITLE
chore(blocky): remove stale dizquetv DNS record + orphan cleanup

### DIFF
--- a/clusters/main/kubernetes/core/blocky/app/helm-release.yaml
+++ b/clusters/main/kubernetes/core/blocky/app/helm-release.yaml
@@ -130,8 +130,6 @@ spec:
           dnsserver: 192.168.10.196
         - domain: tunarr-code.sf.wethecommon.com
           dnsserver: 192.168.10.196
-        - domain: dizquetv.sf.wethecommon.com
-          dnsserver: 192.168.10.196
         - domain: tdarr.sf.wethecommon.com
           dnsserver: 192.168.10.196
         - domain: tinymediamanager.sf.wethecommon.com


### PR DESCRIPTION
Part of a VolSync/MinIO orphan sweep. Removes the dizquetv split-horizon DNS record (app removed in 3722d8d2f, replaced by tunarr). Also deleted out-of-band: dangling media/dizquetv HelmRelease (Flux couldn't reconcile it for 120 days) + MinIO buckets config-dizquetv + config-calibre-web.