### PR TITLE
fix(volsync): bump cache sizes for large-repo backups (lidarr/emby/tunarr/paperless)

### DIFF
--- a/clusters/main/kubernetes/apps/media/emby/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/emby/app/helm-release.yaml
@@ -95,10 +95,10 @@ spec:
             credentials: s3
             dest:
               enabled: true
-              cacheCapacity: 5Gi
+              cacheCapacity: 12Gi
             src:
               enabled: true
-              cacheCapacity: 5Gi
+              cacheCapacity: 12Gi
               trigger:
                 schedule: "15 0 * * *"
       run:

--- a/clusters/main/kubernetes/apps/media/lidarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/lidarr/app/helm-release.yaml
@@ -107,10 +107,14 @@ spec:
             credentials: s3
             dest:
               enabled: true
-              cacheCapacity: 3Gi
+              # Bumped 3Gi → 10Gi 2026-06-10: restic mover hit
+              # "no space left on device" on /cache during index load
+              # (repo had grown large from S3 version bloat before
+              # versioning was suspended). Index needs to fit in cache.
+              cacheCapacity: 10Gi
             src:
               enabled: true
-              cacheCapacity: 3Gi
+              cacheCapacity: 10Gi
       media:
         enabled: true
         type: nfs

--- a/clusters/main/kubernetes/apps/media/tunarr/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/media/tunarr/app/helm-release.yaml
@@ -174,10 +174,10 @@ spec:
             credentials: s3
             src:
               enabled: true
-              cacheCapacity: 3Gi
+              cacheCapacity: 8Gi
             dest:
               enabled: false
-              cacheCapacity: 3Gi
+              cacheCapacity: 8Gi
       streams:
         enabled: true
         size: 2Gi
@@ -188,10 +188,10 @@ spec:
             credentials: s3
             src:
               enabled: true
-              cacheCapacity: 3Gi
+              cacheCapacity: 8Gi
             dest:
               enabled: false
-              cacheCapacity: 3Gi
+              cacheCapacity: 8Gi
       local:
         enabled: true
         size: 5Gi
@@ -202,10 +202,10 @@ spec:
             credentials: s3
             src:
               enabled: true
-              cacheCapacity: 3Gi
+              cacheCapacity: 8Gi
             dest:
               enabled: false
-              cacheCapacity: 3Gi
+              cacheCapacity: 8Gi
       cache:
         enabled: true
         size: 2Gi

--- a/clusters/main/kubernetes/apps/paperless-ngx/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/paperless-ngx/app/helm-release.yaml
@@ -97,10 +97,10 @@ spec:
             credentials: s3
             dest:
               enabled: false
-              cacheCapacity: 2Gi
+              cacheCapacity: 8Gi
             src:
               enabled: true
-              cacheCapacity: 2Gi
+              cacheCapacity: 8Gi
       media:
         enabled: true
         size: 20Gi
@@ -111,10 +111,10 @@ spec:
             credentials: s3
             dest:
               enabled: false
-              cacheCapacity: 2Gi
+              cacheCapacity: 8Gi
             src:
               enabled: true
-              cacheCapacity: 2Gi
+              cacheCapacity: 8Gi
       consume:
         enabled: true
         size: 5Gi


### PR DESCRIPTION
These 4 restic movers hit 'no space left on device' on /cache — their repos bloated from S3 versioning before it was suspended today. Bumping cache PVC sizes. Root cause (versioning) already fixed cluster-wide; MinIO down from 1.5TiB→960GiB and dropping as ILM purges.