### PR TITLE
docs(runbooks): capture 6 operational learnings from 2026-06-10 session

### DIFF
--- a/docs/runbooks/cnpg-netpol-and-immutable-statefulset.md
+++ b/docs/runbooks/cnpg-netpol-and-immutable-statefulset.md
@@ -1,0 +1,75 @@
+## Gotcha 1: CNPG operator blocked by NetworkPolicy
+
+**Symptom:** CNPG `Cluster.status` shows `Instance Status Extraction Error: HTTP communication issue`, and any helm release that waits on the CNPG cluster (immich, paperless-ngx, anything with an embedded `cnpg:` block) fails its reconcile with:
+
+```
+Helm upgrade failed for release media/immich:
+  timeout waiting for: [Cluster/media/immich-cnpg-main status: 'InProgress']
+```
+
+**Root cause:** The CloudNativePG operator (in the `cloudnative-pg` namespace) scrapes each PostgreSQL instance pod's status endpoint at `https://<pod-ip>:8000/pg/status` to populate `Cluster.status.instances`. Operator log:
+
+```
+Cannot extract Pod status ... error: Get "https://172.16.0.211:8000/pg/status": dial tcp 172.16.0.211:8000: i/o timeout
+```
+
+The March 2026 NetworkPolicy rollout (8 app namespaces, ingress-only default-deny) added rules for Traefik/Prometheus/Kuma/intra-namespace but NOT for the CNPG operator. Namespaces WITHOUT netpols (tools, sonarqube, goodmem) had healthy CNPG clusters; namespaces WITH netpols (media, triparr-bot, ollama) all showed the communication error.
+
+**Fix:** Add a `cloudnative-pg` namespaceSelector ingress rule to each affected netpol:
+
+```yaml
+# CNPG operator → instance pod :8000/pg/status
+- from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: cloudnative-pg
+```
+
+Files: `clusters/main/kubernetes/apps/network-policies/app/{media,triparr-bot,ollama}-netpol.yaml`. Shipped in PR #4278 (2026-06-10).
+
+**Detection:** to find all CNPG clusters that are silently degraded:
+```bash
+kubectl get cluster.postgresql.cnpg.io -A | grep -i "communication issue\|Extraction Error"
+```
+
+**Proactive check:** any future namespace that (a) has an ingress-only NetworkPolicy AND (b) hosts a CNPG cluster needs this rule. Grep all netpols for `cloudnative-pg` and cross-reference against `kubectl get cluster.postgresql.cnpg.io -A`.
+
+## Gotcha 2: StatefulSet volumeClaimTemplates is immutable
+
+**Symptom:** A helm release that creates a StatefulSet (Loki single-binary, anything with embedded PVC templates) fails helm upgrade forever after you bump a PVC `size:` value:
+
+```
+Helm upgrade failed for release loki/loki:
+  server-side apply failed for object loki/loki apps/v1, Kind=StatefulSet:
+  StatefulSet.apps "loki" is invalid: spec: Forbidden: updates to statefulset spec
+  for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy',
+  'revisionHistoryLimit', ... are forbidden
+```
+
+The forbidden field is `spec.volumeClaimTemplates` — Kubernetes does not allow in-place edits to a StatefulSet's PVC templates.
+
+**Fix:** Orphan-delete the StatefulSet (keeps the pod + PVC running), then re-reconcile so helm recreates the StatefulSet object with the new template. The new StatefulSet adopts the existing pod and PVC (which Longhorn already expanded):
+
+```bash
+# 1. Orphan-delete — pod and PVC survive
+kubectl delete statefulset -n loki loki --cascade=orphan
+
+# 2. Re-reconcile so helm recreates the StatefulSet
+flux suspend hr loki -n loki && flux resume hr loki -n loki
+# or: flux reconcile hr loki -n loki
+```
+
+The PVC itself can be expanded online separately (Longhorn `allowVolumeExpansion: true`) via `kubectl patch pvc ... -p '{"spec":{"resources":{"requests":{"storage":"60Gi"}}}}'` — that's NOT blocked, only the StatefulSet template edit is. So the full sequence for "grow a StatefulSet's PVC" is: patch the live PVC → bump the helm values → orphan-delete the STS → reconcile.
+
+## Bonus: Prometheus stuck replaying WAL after disk-full
+
+If Prometheus CrashLoopBackOffs with `no space left on device` and then, after you expand the PVC, sits in `1/2 Running` replaying WAL for hours:
+
+- The WAL lives at `/prometheus/prometheus-db/wal/` (NOT `/prometheus/wal/`)
+- `walCompression: true` makes it compact but replay is still slow (~18s/segment when cold)
+- A 50GB+ WAL = multi-hour replay
+- The long-term compacted blocks live in `/prometheus/prometheus-db/01XXXXX...` dirs — those are SAFE, nuking the WAL only loses the most recent (already-lost-anyway) samples
+
+**Fast recovery:** scale Prometheus to 0 via the CR (`kubectl patch prometheus -n kube-prometheus-stack kube-prometheus-stack --type=merge -p '{"spec":{"replicas":0}}'`), mount the PVC in an alpine debug pod, `rm -rf /prometheus/prometheus-db/{wal,chunks_head,chunk_snapshot.*,lock,queries.active}`, scale back to 1. Ready in ~30s instead of 3 hours.
+
+Related: `longhorn-recovery` (if it exists), `post-recovery-crashloop-sweep`.

--- a/docs/runbooks/genconfig-decrypts-in-place.md
+++ b/docs/runbooks/genconfig-decrypts-in-place.md
@@ -1,0 +1,13 @@
+`./forgetool cluster genconfig` and `./clustertool-new genconfig` both run a decrypt pass before invoking talhelper. On success they re-encrypt at the end. **On failure, they leave every SOPS-managed file decrypted on disk** — cleartext sitting in the working tree until manually restored.
+
+Hit during PR 5 of the secrets migration (2026-06-09): forgetool rejected Talos v1.13.4, leaving ~20 `.secret.yaml` files + `clusterenv.yaml` cleartext. Caught via `git status` showing them as modified, then `git diff` showing cleartext credentials in the `-` (HEAD) side and encrypted blobs in the `+` (working tree) side... wait, the other direction: cleartext on the working tree (current disk) side after the decrypt step.
+
+**Why:** Why save this as feedback — this is a foot-gun in the local workflow. Decrypt-on-failure means a failed genconfig followed by an unrelated `git add -A` could commit cleartext credentials to git. The pre-commit hook (`forgetool checkcrypt`) catches some but not all of these (it caught `encryption-config.secret.yaml` once but not the other `.secret.yaml` files that already existed).
+
+**How to apply:** After any failed genconfig:
+1. **First**: `git status --short` — look for unexpected `M` lines on `clusterenv.yaml` and `.secret.yaml` files.
+2. `git restore <each unintentionally-touched file>` — return them to encrypted state. Or `./forgetool encrypt` if intentional edits exist.
+3. NEVER `git add -A` or `git commit -a` after a failed genconfig without first verifying restore.
+4. If genconfig is itself blocked (talhelper version, missing env var), don't run it at all — work around with live JSON patches via `talosctl patch mc` instead.
+
+Related: `forgetool-clustertool-split`, `forgetool-talos-apply-workflow`.

--- a/docs/runbooks/post-recovery-crashloop-sweep.md
+++ b/docs/runbooks/post-recovery-crashloop-sweep.md
@@ -1,0 +1,19 @@
+After a cluster recovery event (Talos boot wedge, control-plane restart, etcd recovery), some pods stay stuck in CrashLoopBackOff indefinitely even though the underlying issue has cleared. The container's own backoff timer becomes the only retry mechanism, and exponential backoff means waits of 5+ minutes between attempts.
+
+Hit during the 2026-06-09 PR 5 incident: `networking/nebula-sync` showed `connect: operation not permitted` to `pihole-k8s.networking.svc:9089` for 5h+ with 14 restarts. Initial reading suggested a Cilium NetworkPolicy denial. Actual cause: nebula-sync started during the post-reboot window when pihole-k8s wasn't ready, hit FATAL on first sync attempt, exited non-zero, and stayed in CrashLoopBackOff. After the cluster fully recovered, `kubectl delete pod -n networking -l app.kubernetes.io/name=nebula-sync` triggered a fresh start — sync completed in <1 second.
+
+**Why:** Why save this as feedback — some containers (Go binaries, single-shot syncers, tight startup-probe services) treat their first failure as fatal rather than implementing internal retry. Kubernetes' container backoff is the only retry trigger, and exponential backoff caps at 5 minutes between attempts. So a 30-second transient at startup can turn into hours of CrashLoopBackOff even after the underlying issue resolves. The EPERM error in particular is misleading — Cilium can briefly return `operation not permitted` during destination endpoint state transitions (pod restart, identity churn), making it look like a NetworkPolicy denial when it's actually transient.
+
+**How to apply:** After any cluster-level recovery event, run this sweep before diagnosing individual pod failures:
+
+```bash
+# Find CrashLoop pods that aren't restart-flapping (low restart count = stuck)
+kubectl get pods -A --no-headers | awk '$4=="CrashLoopBackOff" && $5 < 5'
+
+# Delete to force fresh start
+kubectl get pods -A --no-headers | awk '$4=="CrashLoopBackOff" && $5 < 5 {print "kubectl delete pod -n "$1" "$2}'
+```
+
+If a pod comes back healthy after deletion, the original was transient. If it crashes again, dig in. **Do this BEFORE spending time on Cilium policy verdicts or NetworkPolicy analysis** — those are real but rare causes; transient-during-recovery is much more common.
+
+Related: `genconfig-decrypts-in-place`, `traefik-stale-router-map-after-cascade` (Traefik has a similar pattern — needs rolling restart after rapid Ingress churn).

--- a/docs/runbooks/talos-native-encryption-and-audit.md
+++ b/docs/runbooks/talos-native-encryption-and-audit.md
@@ -1,0 +1,46 @@
+## What Talos provides natively
+
+Discovered 2026-06-10 during the PR 5 etcd-encryption apply. After spending a full day designing, building, auditing, and applying a two-phase Talos patch for etcd encryption + audit logging, an empirical test revealed the cluster had been doing both since bootstrap.
+
+**Encryption at rest (Secrets in etcd):**
+- Cipher: `secretbox` (NaCl secretbox, NOT aesgcm)
+- Key source: `cluster.secretboxEncryptionSecret` in `talsecret.yaml`, set during initial cluster bootstrap
+- Effective encryption-provider-config path (in apiserver pod): `/system/secrets/kubernetes/kube-apiserver/encryptionconfig.yaml`
+- Effective encryption-provider-config path (on host): bind-mounted from Talos state partition
+- Provider order: `[secretbox, identity]` — writes use secretbox, identity is decrypt-fallback
+- Empirical proof: 735+ `k8s:enc:secretbox:v1:key2:` prefixes in raw etcd snapshot, ZERO cleartext for probe Secret
+
+**Audit logging:**
+- Level: `Metadata` for ALL resources (not just Secrets)
+- Policy path (in apiserver pod): `/system/config/kubernetes/kube-apiserver/auditpolicy.yaml`
+- Output path (on host): `/var/log/audit/kube/kube-apiserver-*.log`
+- Rotation: hourly file rolls
+- Default apiserver flags Talos injects (cannot be overridden):
+  - `--audit-log-maxage=30`
+  - `--audit-log-maxbackup=10`
+  - `--audit-log-maxsize=100`
+  - `--audit-log-path=/var/log/audit/kube/kube-apiserver.log`
+  - `--audit-policy-file=/system/config/kubernetes/kube-apiserver/auditpolicy.yaml`
+  - `--encryption-provider-config=/system/secrets/kubernetes/kube-apiserver/encryptionconfig.yaml`
+
+## What does NOT work
+
+Trying to override the above via `cluster.apiServer.extraArgs` or `cluster.apiServer.extraVolumes` in a Talos config patch is **silently dropped**. The values pass schema validation, get accepted by `talosctl patch mc --mode=auto`, the apiserver static pod restarts — but the rendered pod spec contains Talos's own defaults for these specific flag keys, not yours. Your `extraVolumes` for the corresponding hostPath mounts don't appear in the pod either.
+
+Gemini hallucinated a `cluster.apiServer.encryptionConfig` native field during the PR 5 audit. That specific field doesn't exist (verified by direct test: `error decoding document: unknown keys found`). The native mechanism IS real, it just lives in `talsecret.yaml`'s `secretboxEncryptionSecret`, not as a user-facing field in machine config.
+
+## When this matters
+
+**Customizing the audit policy:** the only path is editing `talsecret.yaml` (or whatever Talos uses to source the auditpolicy.yaml — needs investigation). Adding `apiServer.extraArgs.audit-policy-file: ...` to a config patch will not work.
+
+**Rotating the encryption key:** rotate `secretboxEncryptionSecret` in `talsecret.yaml`, regenerate config, apply. Talos handles the rest.
+
+**Wiring audit logs to Loki:** Alloy DaemonSet must hostPath-mount `/var/log/audit/kube/` and scrape `kube-apiserver-*.log` glob. The PR 5 attempt to redirect to `/var/log/k8s-audit/` was inert because Talos owns the log path. Fixed 2026-06-10 in PR #TBD.
+
+## Why this was missed for so long
+
+The original 2026-06-09 PR 5 plan assumed K8s Secrets were cleartext in etcd. That assumption was wrong — Talos has been encrypting since cluster bootstrap. The `bbolt`/etcd-snapshot verification step would have caught it immediately if it had been run BEFORE designing the migration. (Future lesson: empirically verify the "broken" state before designing the fix.)
+
+The cluster-config ConfigMap → cluster-secrets Secret migration (PRs 2-4) WAS still important — that moved 45 credentials from a definitely-cleartext ConfigMap (which IS readable via `kubectl get configmap`) into Secrets that benefit from this native encryption. So PRs 2-4 are not wasted; PR 5 was.
+
+Related: `genconfig-decrypts-in-place`, `forgetool-talos-apply-workflow`.

--- a/docs/runbooks/truecharts-redis-valkey-migration.md
+++ b/docs/runbooks/truecharts-redis-valkey-migration.md
@@ -1,0 +1,92 @@
+## The problem
+
+TrueCharts charts (immich, paperless-ngx, blocky, anything with a bundled `redis:` subchart = redis-2.3.4) default their valkey image to `docker.io/bitnamisecure/valkey:latest`. That's Bitnami's **paid Secure tier** — it returns HTTP 401 on pull. The pods only run because the image is cached on the node (`imagePullPolicy: IfNotPresent`). This survives normal reboots but **breaks on the next Talos OS upgrade** when all images re-pull. blocky-redis dying = cluster DNS degradation.
+
+## What does NOT work
+
+- **Raw image swap to `valkey/valkey`**: the official image is a plain valkey-server, missing the bitnami entrypoint that reads `VALKEY_PASSWORD`/`VALKEY_PORT` env vars and the `/health/ping_*_local.sh` probe scripts. App can't auth, probes fail.
+- **`bitnamilegacy/valkey` (free archive)**: frozen at valkey 8.1.3, whose older valkey-cli doesn't honor the `VALKEYCLI_AUTH` env var the chart's health script uses → readiness probe gets `NOAUTH` → pod stuck 0/1. (The running bitnamisecure image is valkey 9.x which DOES honor it.) bitnamilegacy works for kubectl but NOT valkey-for-this-chart.
+
+## What works: override command/args/probes
+
+The TrueCharts redis subchart accepts container overrides under the parent's `redis:` key. Put this in the app's helm-release `values:`:
+
+```yaml
+redis:
+  image:
+    repository: docker.io/valkey/valkey
+    tag: 8.1.8-alpine
+    pullPolicy: IfNotPresent
+  workload:
+    main:
+      podSpec:
+        containers:
+          main:
+            command:
+              - valkey-server
+            args:
+              - --requirepass
+              - PLACEHOLDERPASSWORD      # the chart's hardcoded placeholder; app uses same
+              - --port
+              - "6379"
+              - --dir
+              - /tmp                     # writable emptyDir; image default /data is owned by UID 999, not the chart's 568
+              - --save
+              - ""                       # disable RDB snapshots
+              - --appendonly
+              - "no"                     # disable AOF — these are ephemeral caches, no PVC
+            probes:
+              liveness:
+                type: exec
+                command: [valkey-cli, -a, PLACEHOLDERPASSWORD, ping]
+              readiness:
+                type: exec
+                command: [valkey-cli, -a, PLACEHOLDERPASSWORD, ping]
+              startup:
+                type: exec
+                command: [valkey-cli, -a, PLACEHOLDERPASSWORD, ping]
+```
+
+Key facts that made it safe:
+- These redis instances have **NO PVC** (`volumeClaimTemplates: []`) — they're ephemeral caches (immich=BullMQ queue, paperless=celery broker, blocky=DNS cache). Nothing to migrate; `--save "" --appendonly no` makes them pure in-memory.
+- The password is the literal string `PLACEHOLDERPASSWORD` (chart default; the app's `REDIS_PASSWORD` env matches it). Hardcode it in the args.
+- The chart's leftover `/health` configmap + emptyDir mounts are harmless — valkey just ignores them.
+
+## The mandatory process (validated 2026-06-10)
+
+1. **Render with `helm template` BEFORE applying** — confirm the override actually lands:
+   ```bash
+   helm template <app> oci://oci.trueforge.org/truecharts/<app> --version <ver> -f /tmp/override.yaml \
+     | python3 -c "import sys,yaml; [print(d['spec']['template']['spec']['containers'][0].get('args')) for d in yaml.safe_load_all(sys.stdin) if isinstance(d,dict) and d.get('kind')=='StatefulSet' and 'redis' in d.get('metadata',{}).get('name','')]"
+   ```
+   Confirm image, command, args, and probe commands render correctly. This turns a fragile guess-and-iterate-on-live-DNS problem into a one-shot apply.
+
+2. **Canary first** — migrate ONE low-risk app (immich), verify redis 1/1 Ready + `valkey-cli -a X ping` = PONG, before touching DNS-critical blocky.
+
+3. **THE GOTCHA — bounce the client app pods after the swap.** The redis server comes up healthy, but the app's ioredis caches a connection to the OLD redis pod IP during the rollout window and gets stuck in backoff (`connect ETIMEDOUT`). The redis itself is fine (prove it with a debug pod hitting the service/ClusterIP/pod-IP). Fix:
+   ```bash
+   kubectl rollout restart deployment -n <ns> <app>
+   ```
+   Verify the ETIMEDOUT errors stop in the fresh pod's logs.
+
+4. **blocky LAST** — it's DNS. After its redis swap + blocky restart, verify:
+   ```bash
+   nslookup grafana.sf.wethecommon.com 192.168.10.195   # internal split-horizon → .196
+   nslookup google.com 192.168.10.195                    # external
+   ```
+
+## Verification it's complete
+
+```bash
+kubectl get pods -A -o json | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print([c['image'] for p in d['items'] for c in p['spec'].get('containers',[]) if 'bitnamisecure' in c.get('image','')])
+"   # → []  (only bitnamilegacy/kubectl on the longhorn rotation CronJob is OK — free, intentional)
+```
+
+## Don't over-migrate
+
+The bitnami exit was driven by a SPECIFIC problem (paid tier 401 on upgrade). The other ~150 deployments use healthy registries (ghcr.io, quay.io, registry.k8s.io, oci.trueforge.org) — no reason to touch them. Migrate problems, not images. This override technique is valkey-specific; it does not generalize to other charts without per-chart analysis.
+
+Related: `kubectl-job-images` (the bitnamilegacy/kubectl decision for longhorn rotation), `post-recovery-crashloop-sweep`.

--- a/docs/runbooks/volsync-s3-versioning-bloat.md
+++ b/docs/runbooks/volsync-s3-versioning-bloat.md
@@ -1,0 +1,54 @@
+## The failure mode (diagnosed 2026-06-10)
+
+24 VolSync ReplicationSources had been stuck for up to 2 months (April 6 cohort). Three linked symptoms, one root cause:
+
+1. **`Bucket quota exceeded`** (radarr): `config-radarr` had a 10 GiB hard quota and was at exactly 10 GiB *counting all versions*.
+2. **`no space left on device` on `/cache`** (lidarr, emby, tunarr, paperless): restic mover couldn't fit the repo index in the cache PVC.
+3. **`failed to take snapshot of the volume ... engine is upgrading to v1.11.1`** (bazarr, calibre, cwa, emby, etc.): stuck Longhorn VolumeSnapshots from the April 1.11 engine upgrade (separate but concurrent — see `VolSync Clone Stuck After Longhorn Upgrade` note in MEMORY.md).
+
+**Root cause for #1 and #2: S3 bucket versioning was enabled on all 40 backup buckets.** restic is content-addressed and immutable — it never overwrites pack files, it writes new ones and `prune` deletes old ones. With S3 versioning ON, every prune-deleted object becomes a *noncurrent version* retained forever. Result: repos bloated 5-30×:
+- plex: 15 GiB current → 481 GiB versioned (466 GiB of dead pack files)
+- emby: 12 → 226 GiB
+- lidarr: 11 → 63 GiB
+- ollama: 82 → 139 GiB
+
+This bloat (a) filled the radarr quota and (b) made restic's repo index too big for the small cache PVCs (2-5 GiB).
+
+## The fix
+
+```bash
+# MinIO client via a throwaway pod (note: minio/mc busybox lacks awk/sed/grep —
+# parse output in a local python, not in the pod shell)
+MC_HOST_tn=http://$S3ID:$S3KEY@192.168.10.122:9000
+
+# 1. Remove the hard quota that's actively blocking
+mc quota clear tn/config-radarr
+
+# 2. Suspend versioning on ALL backup buckets (restic never needs it)
+for b in $(mc ls tn | ...); do mc version suspend tn/$b; done
+
+# 3. ILM rule to auto-expire noncurrent versions (durable mechanism)
+for b in ...; do mc ilm rule add tn/$b --noncurrent-expire-days 1; done
+
+# 4. Immediate purge of existing noncurrent versions (restic-SAFE — these are
+#    pack files restic already prune-deleted; current versions are the live repo)
+for b in ...; do mc rm --recursive --force --versions --non-current tn/$b; done
+
+# 5. Bump cache PVCs for large repos (helm-release volsync.*.cacheCapacity),
+#    delete the undersized cache PVCs so volsync recreates at new size
+#    lidarr 3→10Gi, emby 5→12Gi, tunarr 3→8Gi, paperless 2→8Gi
+```
+
+For the stuck Longhorn snapshots (#3): delete the `readyToUse=false` `-src` VolumeSnapshots + their `-src` clone PVCs + stuck mover pods; VolSync recreates fresh snapshots on the next cycle (per the existing Longhorn-upgrade-stuck-clone note).
+
+## Results
+
+- MinIO usage: 1.5 TiB → 824 GiB and dropping (ILM still purging)
+- 17 of 24 stuck sources re-synced within hours; remaining 4 (big-repo cache issue) clear on next scheduled sync with bigger caches
+- 40 → 38 buckets (deleted orphans config-dizquetv + config-calibre-web)
+
+## Why save this
+
+S3 versioning + restic is a silent time bomb: it works fine for months, then repos cross the quota/cache thresholds simultaneously and ALL backups for an app silently stop. The "successful" last-mover-status masks it — the *condition* wedges at SyncInProgress while `lastSyncStartTime > lastSyncTime`. **Detection:** `kubectl get replicationsource -A` and look for sources whose lastSyncTime is days/weeks old while reason=SyncInProgress. **Prevention:** never enable S3 versioning on a restic/VolSync bucket. If MinIO defaults buckets to versioned, suspend it + add the ILM rule at bucket-creation time.
+
+Related: `cnpg-netpol-and-immutable-sts`, `post-recovery-crashloop-sweep`.


### PR DESCRIPTION
Version-controls the runbook-grade incident learnings from today's recovery + hardening session into docs/runbooks/ (alongside the existing ones). Covers: valkey migration, VolSync S3 versioning bloat, CNPG netpol + immutable STS, Talos native encryption, post-recovery CrashLoop sweep, genconfig decrypt-in-place. All scanned clean of secrets.